### PR TITLE
update `psr/log` and `friendsofphp/php-cs-fixer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
-        "psr/log": "^1"
+        "psr/log": "^1|^2|^3"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "v2.18.4",
+        "friendsofphp/php-cs-fixer": "v2.18.7",
         "jms/serializer": "^2.3 || ^3",
         "phpstan/phpstan": "^0.12.71",
         "phpstan/phpstan-phpunit": "^0.12",


### PR DESCRIPTION
This fixes compatibility with Symfony 6.0. PHP CS Fixer has been updated to the latest minor version because the version that is currently in use suffers from the same incompatibility issue.

I've tested all three versions of `psr/log` - they work just fine (honestly, they don't have enough breaking changes to actually break something in the project).