### PR TITLE
Add support for identical naming strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ another class, are of the type `PropertyTypeClass` that has the method
 `getClassMetadata()` to get the metadata of the nested class. This structure
 is validated to not contain any infinite recursion.
 
+### Property naming strategy
+
+By default, property names will be translated from a camelCased to a lower and 
+snake_cased name (e.g. `myProperty` becomes `my_property`). If you want to keep
+the property name as is, you can change the strategy to `identical` via the 
+following code:
+
+```php
+\Liip\MetadataParser\ModelParser\RawMetadata\PropertyCollection::useIdenticalNamingStrategy();
+```
+
 ### Handling Edge Cases with @Preferred
 
 This library provides its own annotation in `Liip\MetadataParser\Annotation\Preferred`

--- a/src/ModelParser/RawMetadata/PropertyCollection.php
+++ b/src/ModelParser/RawMetadata/PropertyCollection.php
@@ -6,6 +6,8 @@ namespace Liip\MetadataParser\ModelParser\RawMetadata;
 
 final class PropertyCollection implements \JsonSerializable
 {
+    private static $identicalNamingStrategy = false;
+
     /**
      * @var string
      */
@@ -28,7 +30,16 @@ final class PropertyCollection implements \JsonSerializable
 
     public static function serializedName(string $name): string
     {
+        if (self::$identicalNamingStrategy) {
+            return $name;
+        }
+
         return strtolower(preg_replace('/[A-Z]/', '_\\0', $name));
+    }
+
+    public static function useIdenticalNamingStrategy($value = true)
+    {
+        self::$identicalNamingStrategy = $value;
     }
 
     /**

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -37,6 +37,7 @@ abstract class AbstractJMSParserTest extends TestCase
 
     protected function setUp(): void
     {
+        PropertyCollection::useIdenticalNamingStrategy(false);
         $this->parser = new JMSParser(new AnnotationReader());
     }
 
@@ -281,6 +282,26 @@ abstract class AbstractJMSParserTest extends TestCase
 
         $this->assertPropertyCollection('foo', 1, $props[0]);
         $this->assertSame('property', $props[0]->getVariations()[0]->getName(), 'Name of property should match');
+    }
+
+    public function testIdenticalNamingStrategy(): void
+    {
+        $c = new class() {
+            private $myProperty;
+            private $mySecondProperty;
+        };
+
+        PropertyCollection::useIdenticalNamingStrategy();
+        $classMetadata = new RawClassMetadata(\get_class($c));
+        $this->parser->parse($classMetadata);
+
+        $props = $classMetadata->getPropertyCollections();
+        $this->assertCount(2, $props, 'Number of properties should match');
+
+        $this->assertPropertyCollection('myProperty', 1, $props[0]);
+        $this->assertPropertyCollection('mySecondProperty', 1, $props[1]);
+        $this->assertSame('myProperty', $props[0]->getVariations()[0]->getName(), 'Name of property should match');
+        $this->assertSame('mySecondProperty', $props[1]->getVariations()[0]->getName(), 'Name of property should match');
     }
 
     public function testSerializedNameTwice(): void


### PR DESCRIPTION
We use the [IdenticalPropertyNamingStrategy](https://github.com/schmittjoh/serializer/blob/master/src/Naming/IdenticalPropertyNamingStrategy.php) from JMS in our code base. With these changes it is also possible to use this naming strategy with the liip-serializer.

I first thought about adding some sort of naming strategy interface/classes, but this would have required quite a lot of refactoring, so I went with the easier solution. Let me know if that works for you, otherwise I'll invest more time and add a proper naming strategy.