### PR TITLE
Add support for doctrine collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # 0.6.0 (unreleased)
 
 * When running with PHP 8, process attributes in addition to the phpdoc annotations.
+* Support doctrine collections
+* Support `identical` property naming strategy
 
 # 0.5.0
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "psr/log": "^1|^2|^3"
     },
     "require-dev": {
+        "doctrine/collections": "^1.6",
         "friendsofphp/php-cs-fixer": "v2.18.7",
         "jms/serializer": "^2.3 || ^3",
         "phpstan/phpstan": "^0.12.71",

--- a/src/Metadata/PropertyTypeArray.php
+++ b/src/Metadata/PropertyTypeArray.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Liip\MetadataParser\Metadata;
 
+use Doctrine\Common\Collections\Collection;
+
 final class PropertyTypeArray extends AbstractPropertyType
 {
     /**
@@ -33,12 +35,12 @@ final class PropertyTypeArray extends AbstractPropertyType
     public function __toString(): string
     {
         if ($this->subType instanceof PropertyTypeUnknown) {
-            return 'array' . $this->isCollection ? '|Collection' : '';
+            return 'array' . ($this->isCollection ? '|\\' . Collection::class : '');
         }
 
         $array = $this->isHashmap() ? '[string]' : '[]';
         if ($this->isCollection) {
-            $array .= '|Collection';
+            $array .= '|\\' . Collection::class;
         }
 
         return ((string) $this->subType).$array.parent::__toString();

--- a/src/Metadata/PropertyTypeArray.php
+++ b/src/Metadata/PropertyTypeArray.php
@@ -33,8 +33,9 @@ final class PropertyTypeArray extends AbstractPropertyType
     public function __toString(): string
     {
         if ($this->subType instanceof PropertyTypeUnknown) {
-            return 'array';
+            return 'array' . $this->isCollection ? '|Collection' : '';
         }
+
         $array = $this->isHashmap() ? '[string]' : '[]';
         if ($this->isCollection) {
             $array .= '|Collection';

--- a/src/Metadata/PropertyTypeArray.php
+++ b/src/Metadata/PropertyTypeArray.php
@@ -16,12 +16,18 @@ final class PropertyTypeArray extends AbstractPropertyType
      */
     private $hashmap;
 
-    public function __construct(PropertyType $subType, bool $hashmap, bool $nullable)
+    /**
+     * @var bool
+     */
+    private $isCollection;
+
+    public function __construct(PropertyType $subType, bool $hashmap, bool $nullable, bool $isCollection = false)
     {
         parent::__construct($nullable);
 
         $this->subType = $subType;
         $this->hashmap = $hashmap;
+        $this->isCollection = $isCollection;
     }
 
     public function __toString(): string
@@ -30,6 +36,9 @@ final class PropertyTypeArray extends AbstractPropertyType
             return 'array';
         }
         $array = $this->isHashmap() ? '[string]' : '[]';
+        if ($this->isCollection) {
+            $array .= '|Collection';
+        }
 
         return ((string) $this->subType).$array.parent::__toString();
     }
@@ -45,6 +54,11 @@ final class PropertyTypeArray extends AbstractPropertyType
     public function getSubType(): PropertyType
     {
         return $this->subType;
+    }
+
+    public function isCollection(): bool
+    {
+        return $this->isCollection;
     }
 
     /**
@@ -81,13 +95,14 @@ final class PropertyTypeArray extends AbstractPropertyType
         }
 
         $hashmap = $this->isHashmap() || $other->isHashmap();
+        $isCollection = $this->isCollection || $other->isCollection;
         if ($other->getSubType() instanceof PropertyTypeUnknown) {
-            return new self($this->getSubType(), $hashmap, $nullable);
+            return new self($this->getSubType(), $hashmap, $nullable, $isCollection);
         }
         if ($this->getSubType() instanceof PropertyTypeUnknown) {
-            return new self($other->getSubType(), $hashmap, $nullable);
+            return new self($other->getSubType(), $hashmap, $nullable, $isCollection);
         }
 
-        return new self($this->getSubType()->merge($other->getSubType()), $hashmap, $nullable);
+        return new self($this->getSubType()->merge($other->getSubType()), $hashmap, $nullable, $isCollection);
     }
 }

--- a/src/Metadata/PropertyTypeArray.php
+++ b/src/Metadata/PropertyTypeArray.php
@@ -40,7 +40,8 @@ final class PropertyTypeArray extends AbstractPropertyType
 
         $array = $this->isHashmap() ? '[string]' : '[]';
         if ($this->isCollection) {
-            $array .= '|\\' . Collection::class;
+            $collectionType = $this->isHashmap() ? ', string' : '';
+            $array .= sprintf("|\\%s<%s%s>", Collection::class, $this->subType, $collectionType);
         }
 
         return ((string) $this->subType).$array.parent::__toString();

--- a/src/TypeParser/JMSTypeParser.php
+++ b/src/TypeParser/JMSTypeParser.php
@@ -17,6 +17,7 @@ use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
 final class JMSTypeParser
 {
     private const TYPE_ARRAY = 'array';
+    private const TYPE_ARRAY_COLLECTION = 'ArrayCollection';
 
     /**
      * @var Parser
@@ -65,12 +66,13 @@ final class JMSTypeParser
             return new PropertyTypeClass($typeInfo['name'], $nullable);
         }
 
-        if (self::TYPE_ARRAY === $typeInfo['name']) {
+        $isCollection = self::TYPE_ARRAY_COLLECTION === $typeInfo['name'];
+        if (self::TYPE_ARRAY === $typeInfo['name'] || $isCollection) {
             if (1 === \count($typeInfo['params'])) {
-                return new PropertyTypeArray($this->parseType($typeInfo['params'][0], true), false, $nullable);
+                return new PropertyTypeArray($this->parseType($typeInfo['params'][0], true), false, $nullable, $isCollection);
             }
             if (2 === \count($typeInfo['params'])) {
-                return new PropertyTypeArray($this->parseType($typeInfo['params'][1], true), true, $nullable);
+                return new PropertyTypeArray($this->parseType($typeInfo['params'][1], true), true, $nullable, $isCollection);
             }
 
             throw new InvalidTypeException(sprintf('JMS property type array can\'t have more than 2 parameters (%s)', var_export($typeInfo, true)));

--- a/src/TypeParser/JMSTypeParser.php
+++ b/src/TypeParser/JMSTypeParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Liip\MetadataParser\TypeParser;
 
+use Doctrine\Common\Collections\Collection;
 use JMS\Serializer\Type\Parser;
 use Liip\MetadataParser\Exception\InvalidTypeException;
 use Liip\MetadataParser\Metadata\DateTimeOptions;
@@ -66,7 +67,7 @@ final class JMSTypeParser
             return new PropertyTypeClass($typeInfo['name'], $nullable);
         }
 
-        $isCollection = self::TYPE_ARRAY_COLLECTION === $typeInfo['name'];
+        $isCollection = $this->isCollection($typeInfo['name']);
         if (self::TYPE_ARRAY === $typeInfo['name'] || $isCollection) {
             if (1 === \count($typeInfo['params'])) {
                 return new PropertyTypeArray($this->parseType($typeInfo['params'][0], true), false, $nullable, $isCollection);
@@ -92,5 +93,14 @@ final class JMSTypeParser
         }
 
         throw new InvalidTypeException(sprintf('Unknown JMS property found (%s)', var_export($typeInfo, true)));
+    }
+
+    private function isCollection(string $name): bool
+    {
+        if (self::TYPE_ARRAY_COLLECTION === $name || Collection::class === $name) {
+            return true;
+        }
+
+        return is_subclass_of($name, Collection::class);
     }
 }

--- a/src/TypeParser/JMSTypeParser.php
+++ b/src/TypeParser/JMSTypeParser.php
@@ -97,10 +97,6 @@ final class JMSTypeParser
 
     private function isCollection(string $name): bool
     {
-        if (self::TYPE_ARRAY_COLLECTION === $name || Collection::class === $name) {
-            return true;
-        }
-
-        return is_subclass_of($name, Collection::class);
+        return self::TYPE_ARRAY_COLLECTION === $name || is_a($name, Collection::class, true);
     }
 }

--- a/src/TypeParser/PhpTypeParser.php
+++ b/src/TypeParser/PhpTypeParser.php
@@ -63,21 +63,23 @@ final class PhpTypeParser
         }
 
         $isCollection = false;
-        foreach ($types as $key => $type) {
+        $filteredTypes = [];
+        foreach ($types as $type) {
             if (in_array($type, self::TYPES_COLLECTION)) {
                 $isCollection = true;
-                unset($types[$key]);
+            } else {
+                $filteredTypes[] = $type;
             }
         }
 
-        if (0 === \count($types)) {
+        if (0 === \count($filteredTypes)) {
             return new PropertyTypeUnknown($nullable);
         }
-        if (\count($types) > 1) {
+        if (\count($filteredTypes) > 1) {
             throw new InvalidTypeException(sprintf('Multiple types are not supported (%s)', $rawType));
         }
 
-        return $this->createType($types[0], $nullable, $declaringClass, $isCollection);
+        return $this->createType($filteredTypes[0], $nullable, $declaringClass, $isCollection);
     }
 
     /**

--- a/src/TypeParser/PhpTypeParser.php
+++ b/src/TypeParser/PhpTypeParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liip\MetadataParser\TypeParser;
 
 use Doctrine\Common\Annotations\PhpParser;
+use Doctrine\Common\Collections\Collection;
 use Liip\MetadataParser\Exception\InvalidTypeException;
 use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeArray;
@@ -20,17 +21,11 @@ final class PhpTypeParser
     private const TYPE_MIXED = 'mixed';
     private const TYPE_RESOURCE = 'resource';
     private const TYPE_ARRAY = 'array';
-    private const TYPE_ARRAY_COLLECTION = 'ArrayCollection';
-    private const TYPE_COLLECTION = 'Collection';
     private const TYPE_ARRAY_SUFFIX = '[]';
     private const TYPE_HASHMAP_SUFFIX = '[string]';
     private const TYPES_GENERIC = [
         'object',
         'mixed',
-    ];
-    private const TYPES_COLLECTION = [
-        self::TYPE_COLLECTION,
-        self::TYPE_ARRAY_COLLECTION,
     ];
 
     /**
@@ -65,7 +60,8 @@ final class PhpTypeParser
         $isCollection = false;
         $filteredTypes = [];
         foreach ($types as $type) {
-            if (in_array($type, self::TYPES_COLLECTION)) {
+            $resolvedClass = $this->resolveClass($type, $declaringClass);
+            if (Collection::class === $resolvedClass || is_subclass_of($resolvedClass, Collection::class)) {
                 $isCollection = true;
             } else {
                 $filteredTypes[] = $type;

--- a/src/TypeParser/PhpTypeParser.php
+++ b/src/TypeParser/PhpTypeParser.php
@@ -61,7 +61,7 @@ final class PhpTypeParser
         $filteredTypes = [];
         foreach ($types as $type) {
             $resolvedClass = $this->resolveClass($type, $declaringClass);
-            if (Collection::class === $resolvedClass || is_subclass_of($resolvedClass, Collection::class)) {
+            if (is_a($resolvedClass, Collection::class, true)) {
                 $isCollection = true;
             } else {
                 $filteredTypes[] = $type;

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -183,6 +183,18 @@ abstract class AbstractJMSParserTest extends TestCase
         yield [
             new class() {
                 /**
+                 * @JMS\Type("Doctrine\Common\Collections\ArrayCollection<string>")
+                 */
+                private $property;
+            },
+            PropertyTypeArray::class,
+            true,
+            'string[]|Collection|null',
+        ];
+
+        yield [
+            new class() {
+                /**
                  * @JMS\Type("ArrayCollection<string, int>")
                  */
                 private $property;

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -167,6 +167,30 @@ abstract class AbstractJMSParserTest extends TestCase
             true,
             'string[]|null',
         ];
+
+        yield [
+            new class() {
+                /**
+                 * @JMS\Type("ArrayCollection<string>")
+                 */
+                private $property;
+            },
+            PropertyTypeArray::class,
+            true,
+            'string[]|Collection|null',
+        ];
+
+        yield [
+            new class() {
+                /**
+                 * @JMS\Type("ArrayCollection<string, int>")
+                 */
+                private $property;
+            },
+            PropertyTypeArray::class,
+            true,
+            'int[string]|Collection|null',
+        ];
     }
 
     /**

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -177,7 +177,7 @@ abstract class AbstractJMSParserTest extends TestCase
             },
             PropertyTypeArray::class,
             true,
-            'string[]|Collection|null',
+            'string[]|\Doctrine\Common\Collections\Collection|null',
         ];
 
         yield [
@@ -189,7 +189,7 @@ abstract class AbstractJMSParserTest extends TestCase
             },
             PropertyTypeArray::class,
             true,
-            'string[]|Collection|null',
+            'string[]|\Doctrine\Common\Collections\Collection|null',
         ];
 
         yield [
@@ -201,7 +201,7 @@ abstract class AbstractJMSParserTest extends TestCase
             },
             PropertyTypeArray::class,
             true,
-            'int[string]|Collection|null',
+            'int[string]|\Doctrine\Common\Collections\Collection|null',
         ];
     }
 

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -177,7 +177,7 @@ abstract class AbstractJMSParserTest extends TestCase
             },
             PropertyTypeArray::class,
             true,
-            'string[]|\Doctrine\Common\Collections\Collection|null',
+            'string[]|\Doctrine\Common\Collections\Collection<string>|null',
         ];
 
         yield [
@@ -189,7 +189,7 @@ abstract class AbstractJMSParserTest extends TestCase
             },
             PropertyTypeArray::class,
             true,
-            'string[]|\Doctrine\Common\Collections\Collection|null',
+            'string[]|\Doctrine\Common\Collections\Collection<string>|null',
         ];
 
         yield [
@@ -201,7 +201,7 @@ abstract class AbstractJMSParserTest extends TestCase
             },
             PropertyTypeArray::class,
             true,
-            'int[string]|\Doctrine\Common\Collections\Collection|null',
+            'int[string]|\Doctrine\Common\Collections\Collection<int, string>|null',
         ];
     }
 

--- a/tests/ModelParser/Model/WithImports.php
+++ b/tests/ModelParser/Model/WithImports.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Liip\MetadataParser\ModelParser\Model;
 
+use Doctrine\Common\Collections\Collection;
 use Tests\Liip\MetadataParser\ModelParser\Model\BaseModel as Nested;
 use Tests\Liip\MetadataParser\RecursionContextTest as ReflectionBaseModel;
 
@@ -23,4 +24,9 @@ class WithImports
      * @var Nested
      */
     private $aliasSameNamespace;
+
+    /**
+     * @var Nested[]|Collection
+     */
+    private $collectionNamespace;
 }

--- a/tests/ModelParser/Model/WithImports.php
+++ b/tests/ModelParser/Model/WithImports.php
@@ -26,7 +26,7 @@ class WithImports
     private $aliasSameNamespace;
 
     /**
-     * @var Nested[]|Collection
+     * @var Collection<Nested>
      */
     private $collectionNamespace;
 }

--- a/tests/TypeParser/PhpTypeParserTest.php
+++ b/tests/TypeParser/PhpTypeParserTest.php
@@ -125,8 +125,8 @@ class PhpTypeParserTest extends TestCase
         ];
 
         yield [
-            'string[]|Collection|null',
-            'string[]|Collection|null',
+            'string[]|\Doctrine\Common\Collections\Collection|null',
+            'string[]|\Doctrine\Common\Collections\Collection|null',
         ];
 
         yield [
@@ -138,14 +138,13 @@ class PhpTypeParserTest extends TestCase
     public function provideCollectionTypes(): iterable
     {
         yield [
-            'string[]|Collection',
+            'string[]|\Doctrine\Common\Collections\Collection',
         ];
 
         yield [
-            'string[]|ArrayCollection',
+            'string[]|\Doctrine\Common\Collections\ArrayCollection',
         ];
     }
-
 
     /**
      * @dataProvider provideTypes
@@ -202,6 +201,11 @@ class PhpTypeParserTest extends TestCase
         yield [
             'Nested[string][]',
             BaseModel::class.'[string][]',
+        ];
+
+        yield [
+            'Nested[]|Collection',
+            BaseModel::class.'[]|\Doctrine\Common\Collections\Collection'
         ];
     }
 

--- a/tests/TypeParser/PhpTypeParserTest.php
+++ b/tests/TypeParser/PhpTypeParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Liip\MetadataParser\TypeParser;
 
 use Liip\MetadataParser\Exception\InvalidTypeException;
+use Liip\MetadataParser\Metadata\PropertyTypeArray;
 use Liip\MetadataParser\TypeParser\PhpTypeParser;
 use PHPUnit\Framework\TestCase;
 use Tests\Liip\MetadataParser\ModelParser\Model\BaseModel;
@@ -124,10 +125,27 @@ class PhpTypeParserTest extends TestCase
         ];
 
         yield [
+            'string[]|Collection|null',
+            'string[]|Collection|null',
+        ];
+
+        yield [
             '\stdClass[][string]',
             'stdClass[][string]',
         ];
     }
+
+    public function provideCollectionTypes(): iterable
+    {
+        yield [
+            'string[]|Collection',
+        ];
+
+        yield [
+            'string[]|ArrayCollection',
+        ];
+    }
+
 
     /**
      * @dataProvider provideTypes
@@ -140,6 +158,16 @@ class PhpTypeParserTest extends TestCase
         if (null !== $expectedNullable) {
             $this->assertSame($expectedNullable, $type->isNullable(), 'Nullable flag should match');
         }
+    }
+
+    /**
+     * @dataProvider provideCollectionTypes
+     */
+    public function testPropertyTypeArrayIsCollection(string $rawType): void
+    {
+        $type = $this->parser->parseAnnotationType($rawType, new \ReflectionClass($this));
+        self::assertInstanceOf(PropertyTypeArray::class, $type);
+        self::assertTrue($type->isCollection());
     }
 
     public function testMultiType(): void

--- a/tests/TypeParser/PhpTypeParserTest.php
+++ b/tests/TypeParser/PhpTypeParserTest.php
@@ -126,7 +126,7 @@ class PhpTypeParserTest extends TestCase
 
         yield [
             'string[]|\Doctrine\Common\Collections\Collection|null',
-            'string[]|\Doctrine\Common\Collections\Collection|null',
+            'string[]|\Doctrine\Common\Collections\Collection<string>|null',
         ];
 
         yield [
@@ -205,7 +205,7 @@ class PhpTypeParserTest extends TestCase
 
         yield [
             'Nested[]|Collection',
-            BaseModel::class.'[]|\Doctrine\Common\Collections\Collection'
+            BaseModel::class.'[]|\Doctrine\Common\Collections\Collection<' . BaseModel::class . '>'
         ];
     }
 


### PR DESCRIPTION
We have several fields in our models that use the `ArrayCollection` type (see [Type annotation/attribute documentation](http://jmsyst.com/libs/serializer/master/reference/annotations#type)). With these changes it is possible to to handle those types differently in the `liip-serializer` packages.  

I have already prepared the changes for the `liip-serializer`, but before I create the PR, I wanted to make sure this is the correct approach.

Side note: At first I created a new `PropertyTypeArrayCollection` class that handles this case, but this got overly complicated to handle so I went with adding a new property `isCollection` to the existing `PropertyArray` class