### PR TITLE
Add support for attributes when using the JMS parser

### DIFF
--- a/src/ModelParser/JMSParser.php
+++ b/src/ModelParser/JMSParser.php
@@ -30,6 +30,7 @@ use JMS\Serializer\Annotation\XmlList;
 use JMS\Serializer\Annotation\XmlMap;
 use JMS\Serializer\Annotation\XmlRoot;
 use JMS\Serializer\Annotation\XmlValue;
+use JMS\Serializer\Metadata\Driver\AttributeDriver\AttributeReader;
 use JMS\Serializer\Type\Exception\SyntaxError;
 use Liip\MetadataParser\Exception\InvalidTypeException;
 use Liip\MetadataParser\Exception\ParseException;
@@ -70,6 +71,10 @@ abstract class BaseJMSParser implements ModelParserInterface
 
     public function __construct(Reader $annotationsReader)
     {
+        if (PHP_VERSION_ID >= 80000 && class_exists(AttributeReader::class)) {
+            $annotationsReader = new AttributeReader($annotationsReader);
+        }
+
         $this->annotationsReader = $annotationsReader;
         $this->phpTypeParser = new PhpTypeParser();
         $this->jmsTypeParser = new JMSTypeParser();

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -1323,7 +1323,7 @@ abstract class AbstractJMSParserTest extends TestCase
         $this->assertSame($readOnly, $property->isReadOnly(), "Read only flag of property {$name} should match");
     }
 
-    private function assertPropertyType(string $propertyTypeClass, string $typeString, bool $nullable, PropertyType $type): void
+    protected function assertPropertyType(string $propertyTypeClass, string $typeString, bool $nullable, PropertyType $type): void
     {
         $this->assertInstanceOf($propertyTypeClass, $type);
         $this->assertSame($nullable, $type->isNullable(), 'Nullable flag should match');

--- a/tests/ModelParser/JMSParserTest81.php
+++ b/tests/ModelParser/JMSParserTest81.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Liip\MetadataParser\ModelParser;
 
 use JMS\Serializer\Annotation as JMS;
+use Liip\MetadataParser\Metadata\PropertyTypeArray;
+use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
 
 /**
@@ -29,5 +31,76 @@ class JMSParserTest extends AbstractJMSParserTest
 
         $this->assertPropertyCollection('property', 1, $props[0]);
         $this->assertPropertyVariation('property', false, true, $props[0]->getVariations()[0]);
+    }
+
+    public function testAttributes()
+    {
+        $c = new class() {
+            #[JMS\Type('string')]
+            private $property1;
+
+            #[JMS\Type('bool')]
+            public $property2;
+        };
+
+        $classMetadata = new RawClassMetadata(\get_class($c));
+        $this->parser->parse($classMetadata);
+
+        $props = $classMetadata->getPropertyCollections();
+        $this->assertCount(2, $props, 'Number of properties should match');
+
+
+        $this->assertPropertyCollection('property1', 1, $props[0]);
+        $property = $props[0]->getVariations()[0];
+        $this->assertPropertyVariation('property1', false, false, $property);
+        $this->assertPropertyType(PropertyTypePrimitive::class, 'string|null', true, $property->getType());
+
+        $this->assertPropertyCollection('property2', 1, $props[1]);
+        $property = $props[1]->getVariations()[0];
+        $this->assertPropertyVariation('property2', true, false, $property);
+        $this->assertPropertyType(PropertyTypePrimitive::class, 'bool|null', true, $property->getType());
+    }
+
+    public function testAttributesMixedWithAnnotations()
+    {
+        $c = new class() {
+            /**
+             * @JMS\SerializedName("property_mixed")
+             * @JMS\Groups({"group1"})
+             */
+            #[JMS\Type('string')]
+            private $mixedProperty;
+
+            #[JMS\SerializedName('property_attribute')]
+            #[JMS\Type('bool')]
+            public $attributeProperty;
+
+            /**
+             * @JMS\Type("array<string>")
+             */
+            public $annotationsProperty;
+        };
+
+        $classMetadata = new RawClassMetadata(\get_class($c));
+        $this->parser->parse($classMetadata);
+
+        $props = $classMetadata->getPropertyCollections();
+        $this->assertCount(3, $props, 'Number of properties should match');
+
+        $this->assertPropertyCollection('property_mixed', 1, $props[0]);
+        $property = $props[0]->getVariations()[0];
+        $this->assertPropertyVariation('mixedProperty', false, false, $property);
+        $this->assertPropertyType(PropertyTypePrimitive::class, 'string|null', true, $property->getType());
+        $this->assertSame(['group1'], $props[0]->getVariations()[0]->getGroups());
+
+        $this->assertPropertyCollection('property_attribute', 1, $props[1]);
+        $property = $props[1]->getVariations()[0];
+        $this->assertPropertyVariation('attributeProperty', true, false, $property);
+        $this->assertPropertyType(PropertyTypePrimitive::class, 'bool|null', true, $property->getType());
+
+        $this->assertPropertyCollection('annotations_property', 1, $props[2]);
+        $property = $props[2]->getVariations()[0];
+        $this->assertPropertyVariation('annotationsProperty', true, false, $property);
+        $this->assertPropertyType(PropertyTypeArray::class, 'string[]|null', true, $property->getType());
     }
 }


### PR DESCRIPTION
JMS offers an `AttributeReader` class since version `3.14.0` that can be used in addition to any existing annotation reader. This will make it possible to properly parse JMS models that use attributes instead of annotations (or a mix of it).

As mentioned in https://github.com/liip/metadata-parser/pull/29/files#r1034359176 I created a separate PR for adding the attribute reader when using the JMS parser