### PR TITLE
Add conflict for too old jms/serializer versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "jms/serializer": "^2.3 || ^3"
     },
     "conflict": {
-        "doctrine/annotations": "< 1.11"
+        "doctrine/annotations": "< 1.11",
+        "jms/serializer": "< 2.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The supported `jms/serializer` version of the metadata parser is `> 2.3`, but this is only reflected in the `require-dev` section and will not be considered when installing the library via composer somewhere else. Adding a `conflict` with versions lower than `2.3` fixes that issue and makes sure, that only a supported version will be installed.

This is a followup from a failing test in https://github.com/liip/serializer/pull/29#pullrequestreview-1209604604