### PR TITLE
Add support for max-depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * When running with PHP 8, process attributes in addition to the phpdoc annotations.
 * Support doctrine collections
 * Support `identical` property naming strategy
+* Add support for the `MaxDepth` annotation from JMS
 
 # 0.5.0
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,29 @@ class Product
 
 ### Expected Recursion: Working with Flawed Models
 
+#### JMS annotation
+
+If you are using JMS annotations, you can add the `MaxDepth` annotation to 
+properties that might be recursive. 
+
+The following example will tell the metadata parser that the recursion is 
+expected up to a maximum depth of `3`.
+
+```php
+use JMS\Serializer\Annotation as JMS;
+
+class RecursionModel 
+{
+    /**
+     * @JMS\MaxDepth(3)
+     * @JMS\Type("RecursionModel")
+     */
+    public $recursion;
+}
+```
+
+#### Pure PHP 
+
 The RecursionChecker accepts a second parameter to specify places where to
 break recursion. This is useful if your model tree looks like it has recursions
 but actually does not have them. JMSSerializer always acts on the actual data

--- a/src/Metadata/AbstractPropertyMetadata.php
+++ b/src/Metadata/AbstractPropertyMetadata.php
@@ -40,6 +40,11 @@ abstract class AbstractPropertyMetadata implements \JsonSerializable
     private $versionRange;
 
     /**
+     * @var int|null
+     */
+    private $maxDepth = null;
+
+    /**
      * Hashmap of custom information about this property.
      *
      * @var mixed[]
@@ -133,6 +138,7 @@ abstract class AbstractPropertyMetadata implements \JsonSerializable
             'name' => $this->name,
             'is_public' => $this->public,
             'is_read_only' => $this->readOnly,
+            'max_depth' => $this->maxDepth,
         ];
 
         if (\count($this->groups) > 0) {
@@ -193,5 +199,15 @@ abstract class AbstractPropertyMetadata implements \JsonSerializable
     protected function setCustomInformation(string $key, $value): void
     {
         $this->customInformation[$key] = $value;
+    }
+
+    protected function getMaxDepth(): ?int
+    {
+        return $this->maxDepth;
+    }
+
+    protected function setMaxDepth(?int $maxDepth)
+    {
+        $this->maxDepth = $maxDepth;
     }
 }

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -31,7 +31,8 @@ final class PropertyMetadata extends AbstractPropertyMetadata
         VersionRange $versionRange = null,
         array $groups = [],
         PropertyAccessor $accessor = null,
-        array $customInformation = []
+        array $customInformation = [],
+        ?int $maxDepth = null
     ) {
         parent::__construct($name, $readOnly, $public);
         $this->serializedName = $serializedName;
@@ -44,6 +45,8 @@ final class PropertyMetadata extends AbstractPropertyMetadata
         foreach ($customInformation as $key => $value) {
             $this->setCustomInformation((string) $key, $value);
         }
+
+        $this->setMaxDepth($maxDepth);
     }
 
     public function __toString(): string
@@ -62,7 +65,8 @@ final class PropertyMetadata extends AbstractPropertyMetadata
             $property->getVersionRange(),
             $property->getGroups(),
             $property->getAccessor(),
-            $property->getAllCustomInformation()
+            $property->getAllCustomInformation(),
+            $property->getMaxDepth()
         );
     }
 
@@ -74,6 +78,11 @@ final class PropertyMetadata extends AbstractPropertyMetadata
     public function getSerializedName(): string
     {
         return $this->serializedName;
+    }
+
+    public function getMaxDepth(): ?int
+    {
+        return parent::getMaxDepth();
     }
 
     public function jsonSerialize(): array

--- a/src/ModelParser/JMSParser.php
+++ b/src/ModelParser/JMSParser.php
@@ -18,6 +18,7 @@ use JMS\Serializer\Annotation\AccessorOrder;
 use JMS\Serializer\Annotation\Exclude;
 use JMS\Serializer\Annotation\ExclusionPolicy;
 use JMS\Serializer\Annotation\Groups;
+use JMS\Serializer\Annotation\MaxDepth;
 use JMS\Serializer\Annotation\PostDeserialize;
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Since;
@@ -289,6 +290,10 @@ abstract class BaseJMSParser implements ModelParserInterface
 
                 case $annotation instanceof Until:
                     $property->setVersionRange($property->getVersionRange()->withUntil($annotation->version));
+                    break;
+
+                case $annotation instanceof MaxDepth:
+                    $property->setMaxDepth($annotation->depth);
                     break;
 
                 case $annotation instanceof VirtualProperty:

--- a/src/ModelParser/RawMetadata/PropertyVariationMetadata.php
+++ b/src/ModelParser/RawMetadata/PropertyVariationMetadata.php
@@ -87,6 +87,16 @@ final class PropertyVariationMetadata extends AbstractPropertyMetadata
         parent::setVersionRange($version);
     }
 
+    public function getMaxDepth(): ?int
+    {
+        return parent::getMaxDepth();
+    }
+
+    public function setMaxDepth(?int $maxDepth)
+    {
+        parent::setMaxDepth($maxDepth);
+    }
+
     /**
      * The value can be anything that the consumer understands.
      *

--- a/src/RecursionChecker.php
+++ b/src/RecursionChecker.php
@@ -96,12 +96,14 @@ final class RecursionChecker
                     }
                 }
 
-                /*
-                 * Future feature idea: Instead of 2, we could use a configurable maximum recursion depth.
-                 * One could then allow to unroll a recursion up to a certain number and stop it after that.
-                 */
-                if ($propertyContext->countClassNames($propertyClassMetadata->getClassName()) > 2) {
+                $maxDepth = $property->getMaxDepth();
+                $stackCount = $propertyContext->countClassNames($classMetadata->getClassName());
+                if (null === $maxDepth && $stackCount > 2) {
                     throw RecursionException::forClass($propertyClassMetadata->getClassName(), $propertyContext);
+                }
+
+                if (null !== $maxDepth && $stackCount > $maxDepth) {
+                    return $classMetadata;
                 }
 
                 $type->setClassMetadata($this->checkClassMetadata($propertyClassMetadata, $propertyContext));

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -677,7 +677,7 @@ abstract class AbstractJMSParserTest extends TestCase
         $c = new class() {
             /**
              * @JMS\Type("string")
-             * @JMS\MaxDepth(1)
+             * @JMS\Inline()
              */
             private $property;
         };

--- a/tests/RecursionCheckerTest.php
+++ b/tests/RecursionCheckerTest.php
@@ -59,6 +59,36 @@ class RecursionCheckerTest extends TestCase
         $this->createChecker()->check($classMetadata);
     }
 
+    public function testRecursionWithMaxDepth(): void
+    {
+        $customClassType = new PropertyTypeClass(Recursion::class, true);
+        $classMetadata = new ClassMetadata(
+            Recursion::class,
+            [
+                new PropertyMetadata(
+                    'property',
+                    'property',
+                    $customClassType,
+                    true,
+                    false,
+                    null,
+                    [],
+                    null,
+                    [],
+                    2
+                ),
+            ]
+        );
+        $customClassType->setClassMetadata($classMetadata);
+
+        $metadata = $this->createChecker()->check($classMetadata);
+
+        /** @var PropertyTypeClass $type */
+        $type = $metadata->getProperties()[0]->getType();
+        $this->assertInstanceOf(PropertyTypeClass::class, $type);
+        $this->assertCount(1, $type->getClassMetadata()->getProperties());
+    }
+
     public function testRecursionOnArray(): void
     {
         $customClassType = new PropertyTypeClass(Recursion::class, true);


### PR DESCRIPTION
This adds support for defining a maximum depth on a property in case of recursions. Currently only JMS is supported, as in the PHP parser there is currently no way to define a maximum depth without attributes/annotations.

I'll create the corresponding PR in liip-serializer if we agree on the approach here, but if you want to take a look beforehand, you can see the changes here: https://github.com/liip/serializer/compare/master...rebuy-de:liip-serializer:support-max-depth