### PR TITLE
Always check methods, not only if there is a doc comment

### DIFF
--- a/src/ModelParser/JMSParser.php
+++ b/src/ModelParser/JMSParser.php
@@ -123,10 +123,6 @@ abstract class BaseJMSParser implements ModelParserInterface
         }
 
         foreach ($reflClass->getMethods() as $reflMethod) {
-            if (false === $reflMethod->getDocComment()) {
-                continue;
-            }
-
             try {
                 $annotations = $this->annotationsReader->getMethodAnnotations($reflMethod);
             } catch (AnnotationException $e) {

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -1366,7 +1366,7 @@ abstract class AbstractJMSParserTest extends TestCase
         $this->assertSame($typeString, (string) $type);
     }
 
-    private function assertPropertyAccessor(?string $getterMethod, ?string $setterMethod, PropertyAccessor $accessor): void
+    protected function assertPropertyAccessor(?string $getterMethod, ?string $setterMethod, PropertyAccessor $accessor): void
     {
         $this->assertSame($getterMethod, $accessor->getGetterMethod(), 'Getter method of property should match');
         $this->assertSame($setterMethod, $accessor->getSetterMethod(), 'Setter method of property should match');

--- a/tests/ModelParser/JMSParserTest81.php
+++ b/tests/ModelParser/JMSParserTest81.php
@@ -103,4 +103,27 @@ class JMSParserTest extends AbstractJMSParserTest
         $this->assertPropertyVariation('annotationsProperty', true, false, $property);
         $this->assertPropertyType(PropertyTypeArray::class, 'string[]|null', true, $property->getType());
     }
+
+    public function testVirtualPropertyWithoutDocblock(): void
+    {
+        $c = new class() {
+            #[JMS\VirtualProperty]
+            public function foo(): string
+            {
+                return 'bar';
+            }
+        };
+
+        $classMetadata = new RawClassMetadata(\get_class($c));
+        $this->parser->parse($classMetadata);
+
+        $props = $classMetadata->getPropertyCollections();
+        $this->assertCount(1, $props, 'Number of properties should match');
+
+        $this->assertPropertyCollection('foo', 1, $props[0]);
+        $property = $props[0]->getVariations()[0];
+        $this->assertPropertyVariation('foo', true, true, $property);
+        $this->assertPropertyType(PropertyTypePrimitive::class, 'string', false, $property->getType());
+        $this->assertPropertyAccessor('foo', null, $property->getAccessor());
+    }
 }


### PR DESCRIPTION
With this change it is now possible to leave out the docblock comment for methods that have attributes instead of annotations.