### PR TITLE
Directly add doctrine/annotations dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.4', '8.0', '8.1', '8.2']
         include:
-          - php-version: '7.2'
+          - php-version: '7.4'
             composer-flags: '--prefer-stable --prefer-lowest'
     steps:
       - name: Check out code into the workspace

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@
 ###> friendsofphp/php-cs-fixer ###
 /.php_cs
 /.php_cs.cache
+/.php-cs-fixer.php
+/.php-cs-fixer.cache
 ###< friendsofphp/php-cs-fixer ###

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@
 ###< phpunit/phpunit ###
 
 ###> friendsofphp/php-cs-fixer ###
-/.php_cs
-/.php_cs.cache
 /.php-cs-fixer.php
 /.php-cs-fixer.cache
 ###< friendsofphp/php-cs-fixer ###

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,11 +2,16 @@
 
 declare(strict_types=1);
 
-$finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__)
-;
+$config = new PhpCsFixer\Config();
 
-return PhpCsFixer\Config::create()
+$config->setFinder(
+    PhpCsFixer\Finder::create()
+        ->in([
+            __DIR__,
+        ]),
+);
+
+$config
     ->setRiskyAllowed(true)
     ->setRules(
         [
@@ -50,5 +55,6 @@ return PhpCsFixer\Config::create()
             'php_unit_test_case_static_method_calls' => false,
         ]
     )
-    ->setFinder($finder)
 ;
+
+return $config;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 1.1.0 (unreleased)
+
+* Drop support for PHP 7.2 and PHP 7.3
+* Support doctrine annotations `2.x`
+
 # 1.0.0
 
 No changes since 0.6.1.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "issues": "https://github.com/liip/metadata-parser/issues"
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "psr/log": "^1|^2|^3"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "doctrine/collections": "^1.6",
-        "friendsofphp/php-cs-fixer": "v2.18.7",
+        "friendsofphp/php-cs-fixer": "v3.17.0",
         "jms/serializer": "^2.3 || ^3",
         "phpstan/phpstan": "^0.12.71",
         "phpstan/phpstan-phpunit": "^0.12",

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
+        "doctrine/annotations": "^1.13 || ^2.0.1",
         "psr/log": "^1|^2|^3"
     },
     "require-dev": {

--- a/src/TypeParser/PhpTypeParser.php
+++ b/src/TypeParser/PhpTypeParser.php
@@ -137,14 +137,14 @@ final class PhpTypeParser
 
             $reflCurrentClass = $reflClass;
             do {
-                $imports = $this->useStatementsParser->parseClass($reflCurrentClass);
+                $imports = $this->useStatementsParser->parseUseStatements($reflCurrentClass);
                 if (isset($imports[$lowerClassName])) {
                     return $imports[$lowerClassName];
                 }
             } while (false !== ($reflCurrentClass = $reflCurrentClass->getParentClass()));
 
             foreach ($reflClass->getTraits() as $reflTrait) {
-                $imports = $this->useStatementsParser->parseClass($reflTrait);
+                $imports = $this->useStatementsParser->parseUseStatements($reflTrait);
                 if (isset($imports[$lowerClassName])) {
                     return $imports[$lowerClassName];
                 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,13 +2,10 @@
 
 declare(strict_types=1);
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
 (static function (): void {
     if (!is_file($autoloadFile = __DIR__.'/../vendor/autoload.php')) {
         throw new RuntimeException('Did not find vendor/autoload.php. Did you run "composer install --dev"?');
     }
     $loader = require $autoloadFile;
     $loader->add('JMS\Serializer\Tests', __DIR__);
-    AnnotationRegistry::registerLoader('class_exists');
 })();


### PR DESCRIPTION
This dependency was indirectly required via the `jms/serializer` package. As a some of the classes use the annotation parser, I added a direct dependency and also allow `2.0.1`.

I also increased the minimum version of PHP to `7.4` and update the `php-cs-fixer` package to the latest version