### PR TITLE
Try to find a way to access private properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.2.0
+
+* new model parser VisibilityAwarePropertyAccessGuesser to fill in missing accessors for private properties
+
 # 1.1.0
 
 * Drop support for PHP 7.2 and PHP 7.3

--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ use Liip\MetadataParser\ModelParser\JMSParser;
 use Liip\MetadataParser\ModelParser\LiipMetadataAnnotationParser;
 use Liip\MetadataParser\ModelParser\PhpDocParser;
 use Liip\MetadataParser\ModelParser\ReflectionParser;
+use Liip\MetadataParser\ModelParser\VisibilityAwarePropertyAccessGuesser;
 
 $parser = new Parser(
     new ReflectionParser(),
     new PhpDocParser(),
     new JMSParser(new AnnotationReader()),
+    new VisibilityAwarePropertyAccessGuesser(),
     new LiipMetadataAnnotationParser(new AnnotationReader()),
 );
 

--- a/src/ModelParser/VisibilityAwarePropertyAccessGuesser.php
+++ b/src/ModelParser/VisibilityAwarePropertyAccessGuesser.php
@@ -41,7 +41,7 @@ class VisibilityAwarePropertyAccessGuesser implements ModelParserInterface
             $variation = $classMetadata->getPropertyVariation($property->getName());
             $currentAccessor = $variation->getAccessor();
 
-            if (!($currentAccessor->getSetterMethod() && $currentAccessor->hasSetterMethod())) {
+            if (!($currentAccessor->hasGetterMethod() && $currentAccessor->hasSetterMethod())) {
                 $variation->setAccessor(new PropertyAccessor(
                     $currentAccessor->getGetterMethod() ?: $this->guessGetter($reflClass, $variation),
                     $currentAccessor->getSetterMethod() ?: $this->guessSetter($reflClass, $variation),

--- a/src/ModelParser/VisibilityAwarePropertyAccessGuesser.php
+++ b/src/ModelParser/VisibilityAwarePropertyAccessGuesser.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Liip\MetadataParser\ModelParser;
+
+use Liip\MetadataParser\Exception\ParseException;
+use Liip\MetadataParser\Metadata\PropertyAccessor;
+use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
+use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
+use ReflectionClass;
+use ReflectionException;
+
+class VisibilityAwarePropertyAccessGuesser implements ModelParserInterface
+{
+    public function parse(RawClassMetadata $classMetadata): void
+    {
+        try {
+            $reflClass = new ReflectionClass($classMetadata->getClassName());
+        } catch (ReflectionException $e) {
+            throw ParseException::classNotFound($classMetadata->getClassName(), $e);
+        }
+
+        foreach ($classMetadata->getPropertyCollections() as $propertyCollection) {
+            foreach ($propertyCollection->getVariations() as $variation) {
+                $name = $variation->getName();
+
+                if (!$reflClass->hasProperty($name) || $reflClass->getProperty($name)->isPublic()) {
+                    continue;
+                }
+
+                $currentAccessor = $variation->getAccessor();
+
+                if (!($currentAccessor->getSetterMethod() && $currentAccessor->hasSetterMethod())) {
+                    $variation->setAccessor(new PropertyAccessor(
+                        $currentAccessor->getGetterMethod() ?: $this->guessGetter($reflClass, $variation),
+                        $currentAccessor->getSetterMethod() ?: $this->guessSetter($reflClass, $variation),
+                    ));
+                }
+            }
+        }
+    }
+    private function guessGetter(ReflectionClass $reflClass, PropertyVariationMetadata $variation): ?string
+    {
+        foreach (['get', 'is', ''] as $prefix) {
+            $method = "$prefix{$variation->getName()}";
+
+            if (!$reflClass->hasMethod($method)) continue;
+
+            $reflMethod = $reflClass->getMethod($method);
+
+            if ($reflMethod->isPublic() && ($reflMethod->getNumberOfRequiredParameters() === 0)) {
+                return $method;
+            }
+        }
+
+        return null;
+    }
+
+    private function guessSetter(ReflectionClass $reflClass, PropertyVariationMetadata $variation): ?string
+    {
+        foreach (['set', ''] as $prefix) {
+            $method = "$prefix{$variation->getName()}";
+
+            if (!$reflClass->hasMethod($method)) continue;
+
+            $reflMethod = $reflClass->getMethod($method);
+
+            if ($reflMethod->isPublic() && ($reflMethod->getNumberOfParameters() >= 1)) {
+                return $method;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ModelParser/VisibilityAwarePropertyAccessGuesser.php
+++ b/src/ModelParser/VisibilityAwarePropertyAccessGuesser.php
@@ -71,7 +71,7 @@ class VisibilityAwarePropertyAccessGuesser implements ModelParserInterface
 
             $reflMethod = $reflClass->getMethod($method);
 
-            if ($reflMethod->isPublic() && ($reflMethod->getNumberOfParameters() >= 1)) {
+            if ($reflMethod->isPublic() && ($reflMethod->getNumberOfRequiredParameters() == 1)) {
                 return $method;
             }
         }

--- a/tests/ModelParser/VisibilityAwarePropertyAccessGuesserTest.php
+++ b/tests/ModelParser/VisibilityAwarePropertyAccessGuesserTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\MetadataParser\ModelParser;
+
+use Generator;
+use Liip\MetadataParser\ModelParser\ModelParserInterface;
+use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
+use Liip\MetadataParser\ModelParser\ReflectionParser;
+use Liip\MetadataParser\ModelParser\VisibilityAwarePropertyAccessGuesser;
+use PHPUnit\Framework\TestCase;
+
+class VisibilityAwarePropertyAccessGuesserTest extends TestCase
+{
+    /**
+     * @dataProvider provideClassesTests
+     */
+    public function testSimpleClasses($class, array $parsers, int $expectedPropertyCount, ?array $accessType)
+    {
+        $classMetadata = $this->parseClass($class, $parsers);
+
+        $this->assertSame(\get_class($class), $classMetadata->getClassName());
+        $this->assertCount($expectedPropertyCount, $classMetadata->getPropertyCollections(), 'Number of properties should match');
+
+        if ($accessType !== null) {
+            ['public' => $public, 'hasGetter' => $hasGetter, 'hasSetter' => $hasSetter] = $accessType;
+
+            foreach ($classMetadata->getPropertyVariations() as $propertyVariation) {
+                $this->assertSame($public, $propertyVariation->isPublic());
+
+                if (null !== $hasGetter) {
+                    $this->assertSame($hasGetter, $propertyVariation->getAccessor()->hasGetterMethod());
+                }
+                if (null !== $hasSetter) {
+                    $this->assertSame($hasSetter, $propertyVariation->getAccessor()->hasSetterMethod());
+                }
+            }
+        }
+    }
+
+    /**
+     * @param class-string|object $class
+     * @param ModelParserInterface[] $parsers
+     * @return RawClassMetadata
+     */
+    public function parseClass($class, array $parsers): RawClassMetadata
+    {
+        $class = is_object($class) ? \get_class($class) : $class;
+        $classMetadata = new RawClassMetadata($class);
+
+        foreach ($parsers as $parser) {
+            $parser->parse($classMetadata);
+        }
+
+        return $classMetadata;
+    }
+
+    /**
+     * @return Generator<array{
+     *  'class': object,
+     *  'parsers': ModelParserInterface[],
+     *  'expectedPropertyCount': int,
+     *  'accessType': null|array{
+     *     'public': bool,
+     *     'hasGetter': null|bool,
+     *     'hasSetter': null|bool,
+     *  },
+     * }>
+     */
+    public static function provideClassesTests(): Generator
+    {
+        yield 'NoPredecessor' => [
+            'class' => new class() {
+                public ?string $name = 'php';
+            },
+            'parsers' => [
+                new VisibilityAwarePropertyAccessGuesser(),
+            ],
+            'expectedPropertyCount' => 0,
+            'accessType' => null,
+        ];
+        yield 'Empty' => [
+            'class' => new class() {
+            },
+            'parsers' => [
+                new ReflectionParser(),
+                new VisibilityAwarePropertyAccessGuesser(),
+            ],
+            'expectedPropertyCount' => 0,
+            'accessType' => null,
+        ];
+        yield 'SinglePublic' =>  [
+            'class' => new class() {
+                public ?string $name = 'php';
+            },
+            'parsers' => [
+                new ReflectionParser(),
+                new VisibilityAwarePropertyAccessGuesser(),
+            ],
+            'expectedPropertyCount' => 1,
+            'accessType' => [
+                'public' => true,
+                'hasGetter' => null,
+                'hasSetter' => null,
+            ],
+        ];
+        yield 'SinglePrivate' =>  [
+            'class' => new class() {
+                private ?string $name = 'php';
+
+                public function getName(): ?string {
+                    return $this->name;
+                }
+
+                public function setName(?string $name): void {
+                    $this->name = $name;
+                }
+            },
+            'parsers' => [
+                new ReflectionParser(),
+                new VisibilityAwarePropertyAccessGuesser(),
+            ],
+            'expectedPropertyCount' => 1,
+            'accessType' => [
+                'public' => false,
+                'hasGetter' => true,
+                'hasSetter' => true,
+            ],
+        ];
+        yield 'MissingGetter' =>  [
+            'class' => new class() {
+                private ?string $name = 'php';
+
+                public function setName(?string $name): void {
+                    $this->name = $name;
+                }
+            },
+            'parsers' => [
+                new ReflectionParser(),
+                new VisibilityAwarePropertyAccessGuesser(),
+            ],
+            'expectedPropertyCount' => 1,
+            'accessType' => [
+                'public' => false,
+                'hasGetter' => false,
+                'hasSetter' => true,
+            ],
+        ];
+        yield 'MissingSetter' =>  [
+            'class' => new class() {
+                private ?string $name = 'php';
+
+                public function getName(): ?string {
+                    return $this->name;
+                }
+            },
+            'parsers' => [
+                new ReflectionParser(),
+                new VisibilityAwarePropertyAccessGuesser(),
+            ],
+            'expectedPropertyCount' => 1,
+            'accessType' => [
+                'public' => false,
+                'hasGetter' => true,
+                'hasSetter' => false,
+            ],
+        ];
+    }
+}

--- a/tests/ModelParser/VisibilityAwarePropertyAccessGuesserTest.php
+++ b/tests/ModelParser/VisibilityAwarePropertyAccessGuesserTest.php
@@ -16,14 +16,14 @@ class VisibilityAwarePropertyAccessGuesserTest extends TestCase
     /**
      * @dataProvider provideClassesTests
      */
-    public function testSimpleClasses($class, array $parsers, int $expectedPropertyCount, ?array $accessType)
+    public function testSimpleClasses($class, array $parsers, int $expectedPropertyCount, ?array $accessType): void
     {
         $classMetadata = $this->parseClass($class, $parsers);
 
         $this->assertSame(\get_class($class), $classMetadata->getClassName());
         $this->assertCount($expectedPropertyCount, $classMetadata->getPropertyCollections(), 'Number of properties should match');
 
-        if ($accessType !== null) {
+        if (null !== $accessType) {
             ['public' => $public, 'hasGetter' => $hasGetter, 'hasSetter' => $hasSetter] = $accessType;
 
             foreach ($classMetadata->getPropertyVariations() as $propertyVariation) {
@@ -40,13 +40,12 @@ class VisibilityAwarePropertyAccessGuesserTest extends TestCase
     }
 
     /**
-     * @param class-string|object $class
+     * @param class-string|object    $class
      * @param ModelParserInterface[] $parsers
-     * @return RawClassMetadata
      */
     public function parseClass($class, array $parsers): RawClassMetadata
     {
-        $class = is_object($class) ? \get_class($class) : $class;
+        $class = \is_object($class) ? \get_class($class) : $class;
         $classMetadata = new RawClassMetadata($class);
 
         foreach ($parsers as $parser) {
@@ -68,7 +67,7 @@ class VisibilityAwarePropertyAccessGuesserTest extends TestCase
      *  },
      * }>
      */
-    public static function provideClassesTests(): Generator
+    public static function provideClassesTests(): \Generator
     {
         yield 'NoPredecessor' => [
             'class' => new class() {
@@ -90,7 +89,7 @@ class VisibilityAwarePropertyAccessGuesserTest extends TestCase
             'expectedPropertyCount' => 0,
             'accessType' => null,
         ];
-        yield 'SinglePublic' =>  [
+        yield 'SinglePublic' => [
             'class' => new class() {
                 public ?string $name = 'php';
             },
@@ -105,15 +104,17 @@ class VisibilityAwarePropertyAccessGuesserTest extends TestCase
                 'hasSetter' => null,
             ],
         ];
-        yield 'SinglePrivate' =>  [
+        yield 'SinglePrivate' => [
             'class' => new class() {
                 private ?string $name = 'php';
 
-                public function getName(): ?string {
+                public function getName(): ?string
+                {
                     return $this->name;
                 }
 
-                public function setName(?string $name): void {
+                public function setName(?string $name): void
+                {
                     $this->name = $name;
                 }
             },
@@ -128,11 +129,12 @@ class VisibilityAwarePropertyAccessGuesserTest extends TestCase
                 'hasSetter' => true,
             ],
         ];
-        yield 'MissingGetter' =>  [
+        yield 'MissingGetter' => [
             'class' => new class() {
                 private ?string $name = 'php';
 
-                public function setName(?string $name): void {
+                public function setName(?string $name): void
+                {
                     $this->name = $name;
                 }
             },
@@ -147,11 +149,12 @@ class VisibilityAwarePropertyAccessGuesserTest extends TestCase
                 'hasSetter' => true,
             ],
         ];
-        yield 'MissingSetter' =>  [
+        yield 'MissingSetter' => [
             'class' => new class() {
                 private ?string $name = 'php';
 
-                public function getName(): ?string {
+                public function getName(): ?string
+                {
                     return $this->name;
                 }
             },


### PR DESCRIPTION
Currently, when the metadata parser works on models with private properties, if the user does not add the `@JMS\Serializer\Annotation\Accessor` to tell how to access those properties, the parsed metadata cannot be used to generate a functional (de)serializer. If you do use it, you end up with an error for trying to directly access a private property.

Here's an example of this: I create a model that has private properties, and assorted getters/setters. after doing the basic setups of both `liip/metadata-parser` and `liip/serializer`, i try to transform a list of data into a list of that model. As-is, you will get a `Uncaught Error: Cannot access private property IndirectAccess::$name`, and the `VisibilityAwarePropertyAccessGuesser` that should be given to the `new Parser` is meant to fill-in the property accessors of the model with simple getters/setters where necessary.

~~This PR is still missing automated tests~~ _(tests are now done)_, but I wanted to get feedback, mostly because I resorted to making it a `ModelParser` instead of a `PropertyReducer`. The model parser has access to both the property variations and their declaring class, where as the property reducer, which would've been the better place to put this functionality, does not know which class it is handling. Would it be better to adapt the property reducers instead to give them the class too?

```php
<?php

require_once 'vendor/autoload.php';

use Doctrine\Common\Collections\ArrayCollection;
use Doctrine\Common\Collections\Collection;

use Doctrine\Common\Annotations\AnnotationReader;
use Liip\MetadataParser\Builder;
use Liip\MetadataParser\ModelParser\VisibilityAwarePropertyAccessGuesser;
use Liip\MetadataParser\Parser;
use Liip\MetadataParser\RecursionChecker;
use Liip\MetadataParser\ModelParser\JMSParser;
use Liip\MetadataParser\ModelParser\LiipMetadataAnnotationParser;
use Liip\MetadataParser\ModelParser\PhpDocParser;
use Liip\MetadataParser\ModelParser\ReflectionParser;
use Liip\MetadataParser\Reducer\TakeBestReducer;
use Liip\Serializer\Configuration\GeneratorConfiguration;

class IndirectAccess {
    private ?string $name = null;
    private ?string $parent = null;

    public function getName(): ?string {
        return $this->name;
    }

    public function setName(?string $name): void {
        $this->name = $name;
    }

    public function getParent(): ?string {
        return $this->parent;
    }

    public function setParent(?string $parent): void {
        $this->parent = $parent;
    }
}

$parser = new Parser([
    new ReflectionParser(),
    new PhpDocParser(),
    new JMSParser(new AnnotationReader()),
    new LiipMetadataAnnotationParser(new AnnotationReader()),
    // new VisibilityAwarePropertyAccessGuesser(),
]);

$builder = new Builder($parser, new RecursionChecker());
$metadata = $builder->build(IndirectAccess::class, [new TakeBestReducer()]);
$classes = [IndirectAccess::class];
$configuration = GeneratorConfiguration::createFomArray([
    'classes' => array_fill_keys($classes, []),
]);

@mkdir('./cached');
@mkdir('./cached/liip');
$cacheDirectory = 'cached/liip';
$deserializerGenerator = new \Liip\Serializer\DeserializerGenerator(new \Liip\Serializer\Template\Deserialization(), $classes, $cacheDirectory);
$deserializerGenerator->generate($builder);

$serializer = new \Liip\Serializer\Serializer($cacheDirectory);
$indirectAccessesData = [
    ['name' => 'student', 'parent' => 'course'],
];
var_dump(array_map(
    fn($data) => $serializer->fromArray($data, IndirectAccess::class), $indirectAccessesData
));
```