### PR TITLE
Better DateTime type information merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * DateTimeOptions now features a list of deserialization formats instead of a single string one. Passing a string instead of an array to its `__construct`or is deprecated, and will be forbidden in the next version
   Similarly, `getDeserializeFormat(): ?string` is deprecated in favor of `getDeserializeFormats(): ?array`
 
-# 1.3.0 (unreleased)
 
 * Added `PropertyTypeIterable`, which generalizes `PropertyTypeArray` to allow merging Collection informations like one would with arrays, including between interfaces and concrete classes
 * Deprecated `PropertyTypeArray`, please prefer using `PropertyTypeIterable` instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Version 1.x
 
-# 1.4.0 (unreleased)
+# 1.2.0 (unreleased)
 
 * DateTimeOptions now features a list of deserialization formats instead of a single string one. Passing a string instead of an array to its `__construct`or is deprecated, and will be forbidden in the next version
   Similarly, `getDeserializeFormat(): ?string` is deprecated in favor of `getDeserializeFormats(): ?array`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Version 1.x
 
+# 1.4.0 (unreleased)
+
+* DateTimeOptions now features a list of deserialization formats instead of a single string one. Passing a string instead of an array to its `__construct`or is deprecated, and will be forbidden in the next version
+  Similarly, `getDeserializeFormat(): ?string` is deprecated in favor of `getDeserializeFormats(): ?array`
+
 # 1.3.0 (unreleased)
 
 * Added `PropertyTypeIterable`, which generalizes `PropertyTypeArray` to allow merging Collection informations like one would with arrays, including between interfaces and concrete classes

--- a/src/Metadata/DateTimeOptions.php
+++ b/src/Metadata/DateTimeOptions.php
@@ -30,7 +30,7 @@ final class DateTimeOptions implements \JsonSerializable
     {
         $this->format = $format;
         $this->zone = $zone;
-        $deserializeFormat = is_string($deserializeFormat) ? [$deserializeFormat] : $deserializeFormat;
+        $deserializeFormat = \is_string($deserializeFormat) ? [$deserializeFormat] : $deserializeFormat;
         $this->deserializeFormats = $allDeserializeFormats ?: $deserializeFormat;
     }
 

--- a/src/Metadata/DateTimeOptions.php
+++ b/src/Metadata/DateTimeOptions.php
@@ -31,7 +31,7 @@ final class DateTimeOptions implements \JsonSerializable
      *
      * @param string[]|string|null $deserializeFormats
      */
-    public function __construct(?string $format, ?string $zone, $deserializeFormats = null)
+    public function __construct(?string $format, ?string $zone, $deserializeFormats)
     {
         $this->format = $format;
         $this->zone = $zone;

--- a/src/Metadata/DateTimeOptions.php
+++ b/src/Metadata/DateTimeOptions.php
@@ -20,17 +20,18 @@ final class DateTimeOptions implements \JsonSerializable
     private $zone;
 
     /**
-     * Use if a different format should be used for parsing dates than for generating dates.
+     * Use if different formats should be used for parsing dates than for generating dates.
      *
-     * @var string|null
+     * @var string[]|null
      */
-    private $deserializeFormat;
+    private $deserializeFormats;
 
-    public function __construct(?string $format, ?string $zone, ?string $deserializeFormat)
+    public function __construct(?string $format, ?string $zone, ?string $deserializeFormat, ?array $allDeserializeFormats = [])
     {
         $this->format = $format;
         $this->zone = $zone;
-        $this->deserializeFormat = $deserializeFormat;
+        $deserializeFormat = is_string($deserializeFormat) ? [$deserializeFormat] : $deserializeFormat;
+        $this->deserializeFormats = $allDeserializeFormats ?: array_filter([$deserializeFormat ?? $format]);
     }
 
     public function getFormat(): ?string
@@ -45,7 +46,16 @@ final class DateTimeOptions implements \JsonSerializable
 
     public function getDeserializeFormat(): ?string
     {
-        return $this->deserializeFormat;
+        foreach ($this->deserializeFormats as $format) {
+            return $format;
+        }
+
+        return null;
+    }
+
+    public function getDeserializeFormats(): ?array
+    {
+        return $this->deserializeFormats;
     }
 
     public function jsonSerialize(): array
@@ -53,7 +63,8 @@ final class DateTimeOptions implements \JsonSerializable
         return array_filter([
             'format' => $this->format,
             'zone' => $this->zone,
-            'deserialize_format' => $this->deserializeFormat,
+            'deserialize_format' => $this->getDeserializeFormat(),
+            'deserialize_formats' => $this->deserializeFormats,
         ]);
     }
 }

--- a/src/Metadata/DateTimeOptions.php
+++ b/src/Metadata/DateTimeOptions.php
@@ -31,7 +31,7 @@ final class DateTimeOptions implements \JsonSerializable
         $this->format = $format;
         $this->zone = $zone;
         $deserializeFormat = is_string($deserializeFormat) ? [$deserializeFormat] : $deserializeFormat;
-        $this->deserializeFormats = $allDeserializeFormats ?: array_filter([$deserializeFormat ?? $format]);
+        $this->deserializeFormats = $allDeserializeFormats ?: $deserializeFormat;
     }
 
     public function getFormat(): ?string
@@ -44,9 +44,12 @@ final class DateTimeOptions implements \JsonSerializable
         return $this->zone;
     }
 
+    /**
+     * @deprecated Please use {@see getDeserializeFormats}
+     */
     public function getDeserializeFormat(): ?string
     {
-        foreach ($this->deserializeFormats as $format) {
+        foreach ($this->deserializeFormats ?? [] as $format) {
             return $format;
         }
 

--- a/src/Metadata/DateTimeOptions.php
+++ b/src/Metadata/DateTimeOptions.php
@@ -26,12 +26,16 @@ final class DateTimeOptions implements \JsonSerializable
      */
     private $deserializeFormats;
 
-    public function __construct(?string $format, ?string $zone, ?string $deserializeFormat, ?array $allDeserializeFormats = [])
+    /**
+     * @note Passing a string for $deserializeFormats is deprecated, please pass an array instead
+     *
+     * @param string[]|string|null $deserializeFormats
+     */
+    public function __construct(?string $format, ?string $zone, $deserializeFormats = null)
     {
         $this->format = $format;
         $this->zone = $zone;
-        $deserializeFormat = \is_string($deserializeFormat) ? [$deserializeFormat] : $deserializeFormat;
-        $this->deserializeFormats = $allDeserializeFormats ?: $deserializeFormat;
+        $this->deserializeFormats = \is_string($deserializeFormats) ? [$deserializeFormats] : $deserializeFormats;
     }
 
     public function getFormat(): ?string

--- a/src/Metadata/PropertyTypeClass.php
+++ b/src/Metadata/PropertyTypeClass.php
@@ -71,6 +71,9 @@ final class PropertyTypeClass extends AbstractPropertyType
         if (is_a($this->getClassName(), Collection::class, true) && (($other instanceof PropertyTypeIterable) && $other->isCollection())) {
             return $other->merge($this);
         }
+        if (is_a($this->getClassName(), \DateTimeInterface::class, true) && ($other instanceof PropertyTypeDateTime)) {
+            return $other->merge($this);
+        }
         if (!$other instanceof self) {
             throw new \UnexpectedValueException(sprintf('Can\'t merge type %s with %s, they must be the same or unknown', self::class, \get_class($other)));
         }

--- a/src/Metadata/PropertyTypeDateTime.php
+++ b/src/Metadata/PropertyTypeDateTime.php
@@ -67,6 +67,15 @@ final class PropertyTypeDateTime extends AbstractPropertyType
         return null;
     }
 
+    public function getDeserializeFormats(): ?array
+    {
+        if ($this->dateTimeOptions) {
+            return $this->dateTimeOptions->getDeserializeFormats();
+        }
+
+        return null;
+    }
+
     public function merge(PropertyType $other): PropertyType
     {
         $nullable = $this->isNullable() && $other->isNullable();

--- a/src/Metadata/PropertyTypeDateTime.php
+++ b/src/Metadata/PropertyTypeDateTime.php
@@ -58,6 +58,9 @@ final class PropertyTypeDateTime extends AbstractPropertyType
         return null;
     }
 
+    /**
+     * @deprecated Please prefer {@link getDeserializeFormats}
+     */
     public function getDeserializeFormat(): ?string
     {
         if ($this->dateTimeOptions) {

--- a/src/TypeParser/JMSTypeParser.php
+++ b/src/TypeParser/JMSTypeParser.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Liip\MetadataParser\TypeParser;
 
-use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use JMS\Serializer\Type\Parser;
@@ -85,10 +84,9 @@ final class JMSTypeParser
         if (PropertyTypeDateTime::isTypeDateTime($typeInfo['name']) || (self::TYPE_DATETIME_INTERFACE === $typeInfo['name'])) {
             // the case of datetime without params is already handled above, we know we have params
             $deserializeFormats = ($typeInfo['params'][2] ?? null) ?: null;
-            $deserializeFormats = is_string($deserializeFormats) ? [$deserializeFormats] : $deserializeFormats;
+            $deserializeFormats = \is_string($deserializeFormats) ? [$deserializeFormats] : $deserializeFormats;
             // Jms uses DateTime when given DateTimeInterface, {@see \JMS\Serializer\Handler\DateHandler} in jms/serializer
-            $className = ($typeInfo['name'] === self::TYPE_DATETIME_INTERFACE) ? DateTime::class : $typeInfo['name'];
-            $deserializeFormats ??= [];
+            $className = (self::TYPE_DATETIME_INTERFACE === $typeInfo['name']) ? \DateTime::class : $typeInfo['name'];
 
             return PropertyTypeDateTime::fromDateTimeClass(
                 $className,
@@ -96,8 +94,8 @@ final class JMSTypeParser
                 new DateTimeOptions(
                     $typeInfo['params'][0] ?: null,
                     ($typeInfo['params'][1] ?? null) ?: null,
-                    is_array($deserializeFormats) ? reset($deserializeFormats) : $deserializeFormats,
-                    is_array($deserializeFormats) ? $deserializeFormats : [$deserializeFormats],
+                    \is_array($deserializeFormats) ? reset($deserializeFormats) : $deserializeFormats,
+                    $deserializeFormats,
                 )
             );
         }

--- a/src/TypeParser/JMSTypeParser.php
+++ b/src/TypeParser/JMSTypeParser.php
@@ -83,19 +83,19 @@ final class JMSTypeParser
 
         if (PropertyTypeDateTime::isTypeDateTime($typeInfo['name']) || (self::TYPE_DATETIME_INTERFACE === $typeInfo['name'])) {
             // the case of datetime without params is already handled above, we know we have params
+            $serializeFormat = $typeInfo['params'][0] ?: null;
             $deserializeFormats = ($typeInfo['params'][2] ?? null) ?: null;
             $deserializeFormats = \is_string($deserializeFormats) ? [$deserializeFormats] : $deserializeFormats;
-            // Jms uses DateTime when given DateTimeInterface, {@see \JMS\Serializer\Handler\DateHandler} in jms/serializer
+            // Jms defaults to DateTime when given DateTimeInterface despite the documentation saying DateTimeImmutable, {@see \JMS\Serializer\Handler\DateHandler} in jms/serializer
             $className = (self::TYPE_DATETIME_INTERFACE === $typeInfo['name']) ? \DateTime::class : $typeInfo['name'];
 
             return PropertyTypeDateTime::fromDateTimeClass(
                 $className,
                 $nullable,
                 new DateTimeOptions(
-                    $typeInfo['params'][0] ?: null,
+                    $serializeFormat,
                     ($typeInfo['params'][1] ?? null) ?: null,
-                    \is_array($deserializeFormats) ? reset($deserializeFormats) : $deserializeFormats,
-                    $deserializeFormats,
+                    $deserializeFormats ?: [$serializeFormat],
                 )
             );
         }

--- a/src/TypeParser/JMSTypeParser.php
+++ b/src/TypeParser/JMSTypeParser.php
@@ -84,7 +84,9 @@ final class JMSTypeParser
         if (PropertyTypeDateTime::isTypeDateTime($typeInfo['name']) || (self::TYPE_DATETIME_INTERFACE === $typeInfo['name'])) {
             // the case of datetime without params is already handled above, we know we have params
             $serializeFormat = $typeInfo['params'][0] ?: null;
-            $deserializeFormats = ($typeInfo['params'][2] ?? null) ?: null;
+            // {@link \JMS\Serializer\Handler\DateHandler} of jms/serializer defaults to using the serialization format as a deserialization format if none was supplied...
+            $deserializeFormats = ($typeInfo['params'][2] ?? null) ?: $serializeFormat;
+            // ... and always converts single strings to arrays
             $deserializeFormats = \is_string($deserializeFormats) ? [$deserializeFormats] : $deserializeFormats;
             // Jms defaults to DateTime when given DateTimeInterface despite the documentation saying DateTimeImmutable, {@see \JMS\Serializer\Handler\DateHandler} in jms/serializer
             $className = (self::TYPE_DATETIME_INTERFACE === $typeInfo['name']) ? \DateTime::class : $typeInfo['name'];
@@ -95,7 +97,7 @@ final class JMSTypeParser
                 new DateTimeOptions(
                     $serializeFormat,
                     ($typeInfo['params'][1] ?? null) ?: null,
-                    $deserializeFormats ?: [$serializeFormat],
+                    $deserializeFormats,
                 )
             );
         }

--- a/tests/ModelParser/JMSParserTestCase.php
+++ b/tests/ModelParser/JMSParserTestCase.php
@@ -1061,7 +1061,7 @@ abstract class JMSParserTestCase extends TestCase
         $this->assertPropertyType(PropertyTypeDateTime::class, 'DateTime|null', true, $type);
         $this->assertSame('Y-m-d H:i:s', $type->getFormat(), 'Date time format should match');
         $this->assertSame('Europe/Zurich', $type->getZone(), 'Date time zone should match');
-        $this->assertSame('Y-m-d', $type->getDeserializeFormat(), 'Date time deserialize format should match');
+        $this->assertSame(['Y-m-d'], $type->getDeserializeFormats(), 'Date time deserialize format should match');
     }
 
     public function testVirtualPropertyTypeExtendingDateTimeWithUnknown(): void
@@ -1092,7 +1092,7 @@ abstract class JMSParserTestCase extends TestCase
         $this->assertPropertyType(PropertyTypeDateTime::class, 'DateTime|null', true, $type);
         $this->assertSame('Y-m-d H:i:s', $type->getFormat(), 'Date time format should match');
         $this->assertSame('Europe/Zurich', $type->getZone(), 'Date time zone should match');
-        $this->assertSame('Y-m-d', $type->getDeserializeFormat(), 'Date time deserialize format should match');
+        $this->assertSame(['Y-m-d'], $type->getDeserializeFormats(), 'Date time deserialize format should match');
     }
 
     public function testVirtualPropertyInvalidType(): void

--- a/tests/ModelParser/JMSParserTestCase.php
+++ b/tests/ModelParser/JMSParserTestCase.php
@@ -1061,6 +1061,7 @@ abstract class JMSParserTestCase extends TestCase
         $this->assertPropertyType(PropertyTypeDateTime::class, 'DateTime|null', true, $type);
         $this->assertSame('Y-m-d H:i:s', $type->getFormat(), 'Date time format should match');
         $this->assertSame('Europe/Zurich', $type->getZone(), 'Date time zone should match');
+        $this->assertSame('Y-m-d', $type->getDeserializeFormat(), 'Date time deserialize format should match');
         $this->assertSame(['Y-m-d'], $type->getDeserializeFormats(), 'Date time deserialize format should match');
     }
 
@@ -1092,6 +1093,7 @@ abstract class JMSParserTestCase extends TestCase
         $this->assertPropertyType(PropertyTypeDateTime::class, 'DateTime|null', true, $type);
         $this->assertSame('Y-m-d H:i:s', $type->getFormat(), 'Date time format should match');
         $this->assertSame('Europe/Zurich', $type->getZone(), 'Date time zone should match');
+        $this->assertSame('Y-m-d', $type->getDeserializeFormat(), 'Date time deserialize format should match');
         $this->assertSame(['Y-m-d'], $type->getDeserializeFormats(), 'Date time deserialize format should match');
     }
 

--- a/tests/TypeParser/JMSTypeParserTest.php
+++ b/tests/TypeParser/JMSTypeParserTest.php
@@ -122,7 +122,7 @@ class JMSTypeParserTest extends TestCase
             'DateTime|null',
             'Y-m-d H:i:s',
             null,
-            ['Y-m-d H:i:s'],
+            'Y-m-d H:i:s',
         ];
 
         yield [
@@ -138,7 +138,7 @@ class JMSTypeParserTest extends TestCase
             'DateTime|null',
             null,
             null,
-            ['Y-m-d'],
+            'Y-m-d',
         ];
 
         yield [
@@ -146,7 +146,7 @@ class JMSTypeParserTest extends TestCase
             'DateTime|null',
             'Y-m-d H:i:s',
             'Europe/Zurich',
-            ['Y-m-d'],
+            'Y-m-d',
         ];
 
         yield [
@@ -162,7 +162,7 @@ class JMSTypeParserTest extends TestCase
             'DateTimeImmutable|null',
             'Y-m-d H:i:s',
             null,
-            ['Y-m-d H:i:s'],
+            'Y-m-d H:i:s',
         ];
 
         yield [
@@ -178,7 +178,7 @@ class JMSTypeParserTest extends TestCase
             'DateTimeImmutable|null',
             null,
             null,
-            ['Y-m-d'],
+            'Y-m-d',
         ];
 
         yield [
@@ -186,14 +186,14 @@ class JMSTypeParserTest extends TestCase
             'DateTimeImmutable|null',
             'Y-m-d H:i:s',
             'Europe/Zurich',
-            ['Y-m-d'],
+            'Y-m-d',
         ];
     }
 
     /**
      * @dataProvider provideDateTimeTypeCases
      */
-    public function testDateTimeType(string $rawType, string $expectedType, ?string $expectedFormat, ?string $expectedZone, ?array $expectedDeserializeFormats): void
+    public function testDateTimeType(string $rawType, string $expectedType, ?string $expectedFormat, ?string $expectedZone, ?string $expectedDeserializeFormat): void
     {
         /** @var PropertyTypeDateTime $type */
         $type = $this->parser->parse($rawType);
@@ -201,7 +201,8 @@ class JMSTypeParserTest extends TestCase
         $this->assertSame($expectedType, (string) $type, 'Type should match');
         $this->assertSame($expectedFormat, $type->getFormat(), 'Date time format should match');
         $this->assertSame($expectedZone, $type->getZone(), 'Date time zone should match');
-        $this->assertSame($expectedDeserializeFormats, $type->getDeserializeFormats(), 'Date time deserialize format should match');
+        $this->assertSame($expectedDeserializeFormat, $type->getDeserializeFormat(), 'Date time deserialize format should match');
+        $this->assertSame($expectedDeserializeFormat ? [$expectedDeserializeFormat] : null, $type->getDeserializeFormats(), 'Date time deserialize format should match');
     }
 
     public function testInvalidTypeWithParameters(): void

--- a/tests/TypeParser/JMSTypeParserTest.php
+++ b/tests/TypeParser/JMSTypeParserTest.php
@@ -122,7 +122,7 @@ class JMSTypeParserTest extends TestCase
             'DateTime|null',
             'Y-m-d H:i:s',
             null,
-            null,
+            ['Y-m-d H:i:s'],
         ];
 
         yield [
@@ -138,7 +138,7 @@ class JMSTypeParserTest extends TestCase
             'DateTime|null',
             null,
             null,
-            'Y-m-d',
+            ['Y-m-d'],
         ];
 
         yield [
@@ -146,7 +146,7 @@ class JMSTypeParserTest extends TestCase
             'DateTime|null',
             'Y-m-d H:i:s',
             'Europe/Zurich',
-            'Y-m-d',
+            ['Y-m-d'],
         ];
 
         yield [
@@ -162,7 +162,7 @@ class JMSTypeParserTest extends TestCase
             'DateTimeImmutable|null',
             'Y-m-d H:i:s',
             null,
-            null,
+            ['Y-m-d H:i:s'],
         ];
 
         yield [
@@ -178,7 +178,7 @@ class JMSTypeParserTest extends TestCase
             'DateTimeImmutable|null',
             null,
             null,
-            'Y-m-d',
+            ['Y-m-d'],
         ];
 
         yield [
@@ -186,14 +186,14 @@ class JMSTypeParserTest extends TestCase
             'DateTimeImmutable|null',
             'Y-m-d H:i:s',
             'Europe/Zurich',
-            'Y-m-d',
+            ['Y-m-d'],
         ];
     }
 
     /**
      * @dataProvider provideDateTimeTypeCases
      */
-    public function testDateTimeType(string $rawType, string $expectedType, ?string $expectedFormat, ?string $expectedZone, ?string $expectedDeserializeFormat): void
+    public function testDateTimeType(string $rawType, string $expectedType, ?string $expectedFormat, ?string $expectedZone, ?array $expectedDeserializeFormats): void
     {
         /** @var PropertyTypeDateTime $type */
         $type = $this->parser->parse($rawType);
@@ -201,7 +201,7 @@ class JMSTypeParserTest extends TestCase
         $this->assertSame($expectedType, (string) $type, 'Type should match');
         $this->assertSame($expectedFormat, $type->getFormat(), 'Date time format should match');
         $this->assertSame($expectedZone, $type->getZone(), 'Date time zone should match');
-        $this->assertSame($expectedDeserializeFormat, $type->getDeserializeFormat(), 'Date time deserialize format should match');
+        $this->assertSame($expectedDeserializeFormats, $type->getDeserializeFormats(), 'Date time deserialize format should match');
     }
 
     public function testInvalidTypeWithParameters(): void


### PR DESCRIPTION
When properties are annotated with interfaces, and deserialized with concrete classes, the property type informations refuse to merge because one annotates an object's class, and the other the actual dateTime information. In addition, JMS deserializer supports specifying multiple deserialization formats, which is also refused by the ModelParser.

 I've put together a test script to explain my issues. The Student and Course classes all have different datetime information in their JMS annotations vs their typehints (one would have the concrete implementation, and the other an interface name). Those combinations are readable, and seem sound, but they cause an exception when applying the successive informations.

```php
<?php

require_once 'vendor/autoload.php';

use Doctrine\Common\Collections\ArrayCollection;
use Doctrine\Common\Collections\Collection;

use Doctrine\Common\Annotations\AnnotationReader;
use JMS\Serializer\Annotation as Serializer;
use Liip\MetadataParser\Builder;
use Liip\MetadataParser\ModelParser\VisibilityAwarePropertyAccessGuesser;
use Liip\MetadataParser\Parser;
use Liip\MetadataParser\RecursionChecker;
use Liip\MetadataParser\ModelParser\JMSParser;
use Liip\MetadataParser\ModelParser\LiipMetadataAnnotationParser;
use Liip\MetadataParser\ModelParser\PhpDocParser;
use Liip\MetadataParser\ModelParser\ReflectionParser;
use Liip\MetadataParser\Reducer\TakeBestReducer;
use Liip\Serializer\Configuration\GeneratorConfiguration;


class Student {
    public ?string $name = null;

    /**
     * Simple case
     * @Serializer\Type("DateTimeImmutable<'Y-m-d'>")
     */
    public ?DateTimeImmutable $createdAt = null;
    /**
      * Type-hint doesn't match JMS type information (probably not the best practices, but works)
     * @Serializer\Type("DateTimeInterface<'Y-m-d'>")
     */
    public ?Datetime $updatedAt = null;
}

class Course
{
    public ?string $name = null;
    /**
     * @Serializer\Type("ArrayCollection<Student>")
     */
    public ?Collection $students = null;
     /**
      * Multiple deserialization formats
      * Type-hint doesn't exactly match JMS type information
      * Timezone left for another PR
      * @Serializer\Type("DateTime<'Y-m-d\TH:i:sP', '', ['Y-m-d', 'Y-m-d\TH:i:sO']>")
      */
     public ?DateTimeInterface $startDate = null;
     /**
      * Multiple deserialization formats
      * Type-hint doesn't exactly match JMS type information
      * @Serializer\Type("DateTimeImmutable<'Y-m-d\TH:i:sP', '', ['Y-m-d', 'Y-m-d\TH:i:sO']>")
      */
     public ?DateTimeInterface $endDate = null;

    public function __construct()
    {
        $this->students = new ArrayCollection();
    }
}

$parser = new Parser([
    new ReflectionParser(),
    new JMSParser(new AnnotationReader()),
    new PhpDocParser(),
    new LiipMetadataAnnotationParser(new AnnotationReader()),
]);

$builder = new Builder($parser, new RecursionChecker());
$metadata = $builder->build(IndirectAccess::class, [new TakeBestReducer()]);
//$classes = [IndirectAccess::class];
$classes = [Student::class, Course::class];
$configuration = GeneratorConfiguration::createFomArray([
    'classes' => array_fill_keys($classes, []),
]);

@mkdir('./cached');
@mkdir('./cached/liip');
$cacheDirectory = 'cached/liip';
$deserializerGenerator = new \Liip\Serializer\DeserializerGenerator(new \Liip\Serializer\Template\Deserialization(), $classes, $cacheDirectory);
$deserializerGenerator->generate($builder);

$serializer = new \Liip\Serializer\Serializer($cacheDirectory);
var_dump($serializer->fromArray([
    'name' => 'Advanced php - II',
    'students' => [
        ['name' => 'Bob', 'created_at' => '2020-01-01', 'updated_at' => '2023-05-09'],
        ['name' => 'Alice', 'created_at' => '2021-02-12', 'updated_at' => '2023-05-09'],
    ],
    'startDate' => '2021-05-07T23:52:45+0000', //Secondary format of deserialization
    'endDate' => '2023-06-15', //Primary format of deserialization
], Course::class));


```

_PS: I'll have to add automated tests for those changes soon_