### PR TITLE
Deprecate PropertyTypeIterables's Collections in 1.x in favor of Traversables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   Similarly, `getDeserializeFormat(): ?string` is deprecated in favor of `getDeserializeFormats(): ?array`
 * Added `PropertyTypeIterable`, which generalizes `PropertyTypeArray` to allow merging Collection informations like one would with arrays, including between interfaces and concrete classes
 * Deprecated `PropertyTypeArray`, please prefer using `PropertyTypeIterable` instead
+* `PropertyTypeArray::isCollection()` and `PropertyTypeArray::getCollectionClass()` are deprecated, including in its child classes, in favor of `isTraversable()` and `getTraversableClass()`
 * Added a model parser `VisibilityAwarePropertyAccessGuesser` that tries to guess getter and setter methods for non-public properties.
 
 # 1.1.0

--- a/src/Metadata/PropertyTypeArray.php
+++ b/src/Metadata/PropertyTypeArray.php
@@ -63,14 +63,34 @@ class PropertyTypeArray extends AbstractPropertyType
         return $this->subType;
     }
 
+    /**
+     * @deprecated Please prefer using {@link isTraversable}
+     */
     public function isCollection(): bool
     {
         return $this->isCollection;
     }
 
+    /**
+     * @deprecated Please prefer using {@link getTraversableClass}
+     */
     public function getCollectionClass(): ?string
     {
         return $this->isCollection() ? Collection::class : null;
+    }
+
+    public function isTraversable(): bool
+    {
+        return $this->isCollection;
+    }
+
+    public function getTraversableClass(): string
+    {
+        if (!$this->isTraversable()) {
+            throw new \UnexpectedValueException("Iterable type '{$this}' is not traversable.");
+        }
+
+        return \Traversable::class;
     }
 
     /**

--- a/src/Metadata/PropertyTypeArray.php
+++ b/src/Metadata/PropertyTypeArray.php
@@ -73,6 +73,7 @@ class PropertyTypeArray extends AbstractPropertyType
 
     /**
      * @deprecated Please prefer using {@link getTraversableClass}
+     * @return class-string<Collection>|null
      */
     public function getCollectionClass(): ?string
     {
@@ -84,6 +85,9 @@ class PropertyTypeArray extends AbstractPropertyType
         return $this->isCollection;
     }
 
+    /**
+     * @return class-string<\Traversable>|null
+     */
     public function getTraversableClass(): string
     {
         if (!$this->isTraversable()) {

--- a/src/Metadata/PropertyTypeArray.php
+++ b/src/Metadata/PropertyTypeArray.php
@@ -73,6 +73,7 @@ class PropertyTypeArray extends AbstractPropertyType
 
     /**
      * @deprecated Please prefer using {@link getTraversableClass}
+     *
      * @return class-string<Collection>|null
      */
     public function getCollectionClass(): ?string
@@ -86,7 +87,7 @@ class PropertyTypeArray extends AbstractPropertyType
     }
 
     /**
-     * @return class-string<\Traversable>|null
+     * @return class-string<\Traversable>
      */
     public function getTraversableClass(): string
     {

--- a/src/Metadata/PropertyTypeClass.php
+++ b/src/Metadata/PropertyTypeClass.php
@@ -68,7 +68,7 @@ final class PropertyTypeClass extends AbstractPropertyType
         if ($other instanceof PropertyTypeUnknown) {
             return new self($this->className, $nullable);
         }
-        if (is_a($this->getClassName(), Collection::class, true) && (($other instanceof PropertyTypeIterable) && $other->isCollection())) {
+        if (is_a($this->getClassName(), Collection::class, true) && (($other instanceof PropertyTypeIterable) && $other->isTraversable())) {
             return $other->merge($this);
         }
         if (is_a($this->getClassName(), \DateTimeInterface::class, true) && ($other instanceof PropertyTypeDateTime)) {

--- a/src/Metadata/PropertyTypeIterable.php
+++ b/src/Metadata/PropertyTypeIterable.php
@@ -46,12 +46,12 @@ final class PropertyTypeIterable extends PropertyTypeArray
 
     /**
      * @deprecated Please prefer using {@link getTraversableClass}
+     *
      * @return class-string<Collection>|null
      */
     public function getCollectionClass(): ?string
     {
         return $this->isCollection() ? null : $this->traversableClass;
-
     }
 
     /**
@@ -63,7 +63,7 @@ final class PropertyTypeIterable extends PropertyTypeArray
     }
 
     /**
-     * @return class-string<\Traversable>|null
+     * @return class-string<\Traversable>
      */
     public function getTraversableClass(): string
     {

--- a/src/Metadata/PropertyTypeIterable.php
+++ b/src/Metadata/PropertyTypeIterable.php
@@ -17,52 +17,73 @@ final class PropertyTypeIterable extends PropertyTypeArray
     /**
      * @var string
      */
-    private $collectionClass;
+    private $traversableClass;
 
     /**
-     * @param class-string<\Traversable>|null $collectionClass
+     * @param class-string<\Traversable>|null $traversableClass
      */
-    public function __construct(PropertyType $subType, bool $hashmap, bool $nullable, string $collectionClass = null)
+    public function __construct(PropertyType $subType, bool $hashmap, bool $nullable, string $traversableClass = null)
     {
-        parent::__construct($subType, $hashmap, $nullable, null != $collectionClass);
+        parent::__construct($subType, $hashmap, $nullable, null != $traversableClass);
 
-        $this->collectionClass = $collectionClass;
+        $this->traversableClass = $traversableClass;
     }
 
     public function __toString(): string
     {
         if ($this->subType instanceof PropertyTypeUnknown) {
-            return 'array'.($this->isCollection() ? '|\\'.$this->collectionClass : '');
+            return 'array'.($this->isTraversable() ? '|\\'.$this->traversableClass : '');
         }
 
         $array = $this->isHashmap() ? '[string]' : '[]';
-        if ($this->isCollection()) {
+        if ($this->isTraversable()) {
             $collectionType = $this->isHashmap() ? ', string' : '';
-            $array .= sprintf('|\\%s<%s%s>', $this->collectionClass, $this->subType, $collectionType);
+            $array .= sprintf('|\\%s<%s%s>', $this->traversableClass, $this->subType, $collectionType);
         }
 
         return ((string) $this->subType).$array.AbstractPropertyType::__toString();
     }
 
+    /**
+     * @deprecated Please prefer using {@link getTraversableClass}
+     */
     public function getCollectionClass(): ?string
     {
-        return $this->collectionClass;
+        return $this->traversableClass;
     }
 
+    /**
+     * @deprecated Please prefer using {@link isTraversable}
+     */
     public function isCollection(): bool
     {
-        return null != $this->getCollectionClass();
+        return null != $this->getTraversableClass();
+    }
+
+    public function getTraversableClass(): string
+    {
+        if (!$this->isTraversable()) {
+            throw new \UnexpectedValueException("Iterable type '{$this}' is not traversable.");
+        }
+
+        return $this->traversableClass;
+    }
+
+    public function isTraversable(): bool
+    {
+        return null != $this->traversableClass;
     }
 
     public function merge(PropertyType $other): PropertyType
     {
         $nullable = $this->isNullable() && $other->isNullable();
+        $thisTraversableClass = $this->isTraversable() ? $this->getTraversableClass() : null;
 
         if ($other instanceof PropertyTypeUnknown) {
-            return new self($this->subType, $this->isHashmap(), $nullable, $this->getCollectionClass());
+            return new self($this->subType, $this->isHashmap(), $nullable, $thisTraversableClass);
         }
-        if ($this->isCollection() && (($other instanceof PropertyTypeClass) && is_a($other->getClassName(), Collection::class, true))) {
-            return new self($this->getSubType(), $this->isHashmap(), $nullable, $this->findCommonCollectionClass($this->getCollectionClass(), $other->getClassName()));
+        if ($this->isTraversable() && (($other instanceof PropertyTypeClass) && is_a($other->getClassName(), \Traversable::class, true))) {
+            return new self($this->getSubType(), $this->isHashmap(), $nullable, $this->findCommonCollectionClass($thisTraversableClass, $other->getClassName()));
         }
         if (!$other instanceof parent) {
             throw new \UnexpectedValueException(sprintf('Can\'t merge type %s with %s, they must be the same or unknown', self::class, \get_class($other)));
@@ -77,13 +98,9 @@ final class PropertyTypeIterable extends PropertyTypeArray
             throw new \UnexpectedValueException(sprintf('Can\'t merge type %s with %s, can\'t change hashmap into plain array', self::class, \get_class($other)));
         }
 
-        if ($other->isCollection()) {
-            $otherCollectionClass = ($other instanceof self) ? $other->getCollectionClass() : Collection::class;
-        } else {
-            $otherCollectionClass = null;
-        }
+        $otherTraversableClass = $other->isTraversable() ? $other->getTraversableClass() : null;
         $hashmap = $this->isHashmap() || $other->isHashmap();
-        $commonClass = $this->findCommonCollectionClass($this->getCollectionClass(), $otherCollectionClass);
+        $commonClass = $this->findCommonCollectionClass($thisTraversableClass, $otherTraversableClass);
 
         if ($other->getSubType() instanceof PropertyTypeUnknown) {
             return new self($this->getSubType(), $hashmap, $nullable, $commonClass);
@@ -99,7 +116,7 @@ final class PropertyTypeIterable extends PropertyTypeArray
      * Find the most derived class that doesn't deny both class hints, meaning the most derived
      * between left and right if one is a child of the other
      */
-    protected function findCommonCollectionClass(?string $left, ?string $right): ?string
+    private function findCommonCollectionClass(?string $left, ?string $right): ?string
     {
         if (null === $right) {
             return $left;
@@ -115,6 +132,6 @@ final class PropertyTypeIterable extends PropertyTypeArray
             return $right;
         }
 
-        throw new \UnexpectedValueException("Collection classes '{$left}' and '{$right}' do not match.");
+        throw new \UnexpectedValueException("Traversable classes '{$left}' and '{$right}' do not match.");
     }
 }

--- a/src/Metadata/PropertyTypeIterable.php
+++ b/src/Metadata/PropertyTypeIterable.php
@@ -46,10 +46,12 @@ final class PropertyTypeIterable extends PropertyTypeArray
 
     /**
      * @deprecated Please prefer using {@link getTraversableClass}
+     * @return class-string<Collection>|null
      */
     public function getCollectionClass(): ?string
     {
-        return $this->traversableClass;
+        return $this->isCollection() ? null : $this->traversableClass;
+
     }
 
     /**
@@ -57,9 +59,12 @@ final class PropertyTypeIterable extends PropertyTypeArray
      */
     public function isCollection(): bool
     {
-        return null != $this->getTraversableClass();
+        return (null != $this->traversableClass) && is_a($this->traversableClass, Collection::class, true);
     }
 
+    /**
+     * @return class-string<\Traversable>|null
+     */
     public function getTraversableClass(): string
     {
         if (!$this->isTraversable()) {

--- a/tests/Metadata/PropertyTypeIterableTest.php
+++ b/tests/Metadata/PropertyTypeIterableTest.php
@@ -31,7 +31,19 @@ class PropertyTypeIterableTest extends TestCase
         $subType = new PropertyTypePrimitive('int', false);
         $list = new PropertyTypeIterable($subType, false, false);
 
-        $this->assertFalse($list->isCollection());
+        $this->assertFalse($list->isTraversable());
+    }
+
+    /**
+     * @deprecated This only checks the behaviour of deprecated class {@see PropertyTypeArray}
+     */
+    public function testDefaultTraversableClassIsTraversableInterface(): void
+    {
+        $subType = new PropertyTypePrimitive('int', false);
+        $collection = new PropertyTypeArray($subType, false, false, true);
+
+        $this->assertTrue($collection->isTraversable());
+        $this->assertSame(\Traversable::class, $collection->getTraversableClass());
     }
 
     /**
@@ -51,9 +63,9 @@ class PropertyTypeIterableTest extends TestCase
         $subType = new PropertyTypePrimitive('int', false);
         $collection = new PropertyTypeIterable($subType, false, false, ArrayCollection::class);
 
-        $this->assertTrue($collection->isCollection());
-        $this->assertNotSame(Collection::class, $collection->getCollectionClass());
-        $this->assertSame(ArrayCollection::class, $collection->getCollectionClass());
+        $this->assertTrue($collection->isTraversable());
+        $this->assertNotSame(\Traversable::class, $collection->getTraversableClass());
+        $this->assertSame(ArrayCollection::class, $collection->getTraversableClass());
     }
 
     public function testMergeListWithClassCollection(): void
@@ -74,9 +86,9 @@ class PropertyTypeIterableTest extends TestCase
         $result = $defaultCollection->merge($typeHintedCollection);
         $this->assertInstanceOf(PropertyTypeArray::class, $result);
         /* @var PropertyTypeIterable $result */
-        $this->assertTrue($result->isCollection());
+        $this->assertTrue($result->isTraversable());
         $this->assertSame((string) $defaultCollection->getSubType(), (string) $result->getSubType());
-        $this->assertSame(Collection::class, $result->getCollectionClass());
+        $this->assertSame(\Traversable::class, $result->getTraversableClass());
     }
 
     public function testMergeExplicitCollectionListWithClassCollection(): void
@@ -88,9 +100,9 @@ class PropertyTypeIterableTest extends TestCase
         $result = $explicitCollection->merge($typeHintedCollection);
         $this->assertInstanceOf(PropertyTypeIterable::class, $result);
         /* @var PropertyTypeIterable $result */
-        $this->assertTrue($result->isCollection());
+        $this->assertTrue($result->isTraversable());
         $this->assertSame((string) $explicitCollection->getSubType(), (string) $result->getSubType());
-        $this->assertSame(ArrayCollection::class, $result->getCollectionClass());
+        $this->assertSame(ArrayCollection::class, $result->getTraversableClass());
     }
 
     public function testMergeExplicitCollectionListWithDefaultCollection(): void
@@ -102,9 +114,9 @@ class PropertyTypeIterableTest extends TestCase
         $result = $explicitCollection->merge($defaultCollection);
         $this->assertInstanceOf(PropertyTypeIterable::class, $result);
         /* @var PropertyTypeIterable $result */
-        $this->assertTrue($result->isCollection());
+        $this->assertTrue($result->isTraversable());
         $this->assertSame((string) $explicitCollection->getSubType(), (string) $result->getSubType());
-        $this->assertSame(ArrayCollection::class, $result->getCollectionClass());
+        $this->assertSame(ArrayCollection::class, $result->getTraversableClass());
     }
 
     public function testMergeDefaultCollectionListWithExplicitCollection(): void
@@ -116,7 +128,7 @@ class PropertyTypeIterableTest extends TestCase
         $result = $defaultCollection->merge($explicitCollection);
         $this->assertInstanceOf(PropertyTypeArray::class, $result);
         /* @var PropertyTypeIterable $result */
-        $this->assertTrue($result->isCollection());
+        $this->assertTrue($result->isTraversable());
         $this->assertSame((string) $explicitCollection->getSubType(), (string) $result->getSubType());
         $this->assertSame(Collection::class, $result->getCollectionClass());
     }
@@ -130,9 +142,9 @@ class PropertyTypeIterableTest extends TestCase
         $result = $typeHintedCollection->merge($explicitCollection);
         $this->assertInstanceOf(PropertyTypeIterable::class, $result);
         /* @var PropertyTypeIterable $result */
-        $this->assertTrue($result->isCollection());
+        $this->assertTrue($result->isTraversable());
         $this->assertSame((string) $explicitCollection->getSubType(), (string) $result->getSubType());
-        $this->assertSame(ArrayCollection::class, $result->getCollectionClass());
+        $this->assertSame(ArrayCollection::class, $result->getTraversableClass());
     }
 
     public function testMergeListAndCollection(): void
@@ -144,8 +156,8 @@ class PropertyTypeIterableTest extends TestCase
         foreach ([$list->merge($collection), $collection->merge($list)] as $result) {
             $this->assertInstanceOf(PropertyTypeIterable::class, $result);
             /* @var PropertyTypeIterable $result */
-            $this->assertTrue($result->isCollection());
-            $this->assertSame(Collection::class, $result->getCollectionClass());
+            $this->assertTrue($result->isTraversable());
+            $this->assertSame(Collection::class, $result->getTraversableClass());
             $this->assertSame((string) $list->getSubType(), (string) $result->getSubType());
         }
     }
@@ -159,8 +171,8 @@ class PropertyTypeIterableTest extends TestCase
         foreach ([$list->merge($collection), $collection->merge($list)] as $result) {
             $this->assertInstanceOf(PropertyTypeIterable::class, $result);
             /* @var PropertyTypeIterable $result */
-            $this->assertTrue($result->isCollection());
-            $this->assertSame(ArrayCollection::class, $result->getCollectionClass());
+            $this->assertTrue($result->isTraversable());
+            $this->assertSame(ArrayCollection::class, $result->getTraversableClass());
             $this->assertSame((string) $list->getSubType(), (string) $result->getSubType());
         }
     }

--- a/tests/TypeParser/PhpTypeParserTest.php
+++ b/tests/TypeParser/PhpTypeParserTest.php
@@ -166,7 +166,7 @@ class PhpTypeParserTest extends TestCase
     {
         $type = $this->parser->parseAnnotationType($rawType, new \ReflectionClass($this));
         self::assertInstanceOf(PropertyTypeIterable::class, $type);
-        self::assertTrue($type->isCollection());
+        self::assertTrue($type->isTraversable());
     }
 
     public function testMultiType(): void


### PR DESCRIPTION
see https://github.com/liip/metadata-parser/pull/43#discussion_r1375777054