### PR TITLE
Properly support PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
         include:
           - php-version: '8.0'
             composer-flags: '--prefer-stable --prefer-lowest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         php-version: ['7.4', '8.0', '8.1', '8.2']
         include:
-          - php-version: '7.4'
+          - php-version: '8.0'
             composer-flags: '--prefer-stable --prefer-lowest'
     steps:
       - name: Check out code into the workspace

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -38,6 +38,10 @@ $config
             'static_lambda' => true,
             'ternary_to_null_coalescing' => true,
             'void_return' => true,
+            'new_with_parentheses' => false,
+            'php_unit_data_provider_static' => false,
+            'php_unit_data_provider_name' => false,
+            'php_unit_data_provider_return_type' => false,
 
             // Don't mark tests as @internal
             'php_unit_internal_class' => false,

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "doctrine/collections": "^1.6",
-        "friendsofphp/php-cs-fixer": "v3.17.0",
+        "friendsofphp/php-cs-fixer": "v3.68.1",
         "jms/serializer": "^2.3 || ^3",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "issues": "https://github.com/liip/metadata-parser/issues"
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "doctrine/annotations": "^1.13 || ^2.0.1",
         "psr/log": "^1|^2|^3"

--- a/src/Annotation/Preferred.php
+++ b/src/Annotation/Preferred.php
@@ -11,7 +11,6 @@ namespace Liip\MetadataParser\Annotation;
  * different versions with JMS serializer, and not specifying any version.
  *
  * @Annotation
- *
  * @Target({"METHOD", "PROPERTY"})
  */
 final class Preferred

--- a/src/Exception/InvalidTypeException.php
+++ b/src/Exception/InvalidTypeException.php
@@ -8,10 +8,10 @@ final class InvalidTypeException extends SchemaException
 {
     private const CLASS_NOT_FOUND = 'Class or interface "%s" could not be found, maybe it\'s not autoloadable?';
 
-    public static function classNotFound(string $className, \Exception $previousException = null): self
+    public static function classNotFound(string $className, ?\Exception $previousException = null): self
     {
         return new self(
-            sprintf(self::CLASS_NOT_FOUND, $className),
+            \sprintf(self::CLASS_NOT_FOUND, $className),
             $previousException ? $previousException->getCode() : 0,
             $previousException
         );

--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -22,7 +22,7 @@ final class ParseException extends SchemaException
     public static function classNotFound(string $className, \Exception $previousException): self
     {
         return new self(
-            sprintf(self::CLASS_NOT_FOUND, $className),
+            \sprintf(self::CLASS_NOT_FOUND, $className),
             $previousException->getCode(),
             $previousException
         );
@@ -31,7 +31,7 @@ final class ParseException extends SchemaException
     public static function classError(string $className, \Exception $previousException): self
     {
         return new self(
-            sprintf(self::CLASS_ERROR, $className, $previousException->getMessage()),
+            \sprintf(self::CLASS_ERROR, $className, $previousException->getMessage()),
             $previousException->getCode(),
             $previousException
         );
@@ -40,7 +40,7 @@ final class ParseException extends SchemaException
     public static function propertyError(string $className, string $propertyName, \Exception $previousException): self
     {
         return new self(
-            sprintf(self::PROPERTY_ERROR, $className, $propertyName, $previousException->getMessage()),
+            \sprintf(self::PROPERTY_ERROR, $className, $propertyName, $previousException->getMessage()),
             $previousException->getCode(),
             $previousException
         );
@@ -49,7 +49,7 @@ final class ParseException extends SchemaException
     public static function propertyTypeError(string $className, string $propertyName, \Exception $previousException): self
     {
         return new self(
-            sprintf(self::PROPERTY_TYPE_ERROR, $className, $propertyName, $previousException->getMessage()),
+            \sprintf(self::PROPERTY_TYPE_ERROR, $className, $propertyName, $previousException->getMessage()),
             $previousException->getCode(),
             $previousException
         );
@@ -57,13 +57,13 @@ final class ParseException extends SchemaException
 
     public static function propertyTypeNameNull(string $className, string $propertyName): self
     {
-        return new self(sprintf(self::PROPERTY_TYPE_NAME_NULL, $className, $propertyName));
+        return new self(\sprintf(self::PROPERTY_TYPE_NAME_NULL, $className, $propertyName));
     }
 
     public static function propertyTypeConflict(string $className, string $propertyName, string $typeA, string $typeB, \Exception $previousException): self
     {
         return new self(
-            sprintf(self::PROPERTY_TYPE_CONFLICT, $className, $propertyName, $typeA, $typeB),
+            \sprintf(self::PROPERTY_TYPE_CONFLICT, $className, $propertyName, $typeA, $typeB),
             $previousException->getCode(),
             $previousException
         );
@@ -71,26 +71,26 @@ final class ParseException extends SchemaException
 
     public static function unsupportedClassAnnotation(string $className, string $annotation): self
     {
-        return new self(sprintf(self::UNSUPPORTED_CLASS_ANNOTATION, $className, $annotation));
+        return new self(\sprintf(self::UNSUPPORTED_CLASS_ANNOTATION, $className, $annotation));
     }
 
     public static function unsupportedPropertyAnnotation(string $className, string $propertyName, string $annotation): self
     {
-        return new self(sprintf(self::UNSUPPORTED_PROPERTY_ANNOTATION, $className, $propertyName, $annotation));
+        return new self(\sprintf(self::UNSUPPORTED_PROPERTY_ANNOTATION, $className, $propertyName, $annotation));
     }
 
     public static function nonPublicMethod(string $className, string $methodName): self
     {
-        return new self(sprintf(self::NON_PUBLIC_METHOD, $className, $methodName));
+        return new self(\sprintf(self::NON_PUBLIC_METHOD, $className, $methodName));
     }
 
     public static function propertyAlreadyExists(string $propertyName, string $className): self
     {
-        return new self(sprintf(self::PROPERTY_ALREADY_EXISTS, $propertyName, $className));
+        return new self(\sprintf(self::PROPERTY_ALREADY_EXISTS, $propertyName, $className));
     }
 
     public static function classNotParsed(string $notFoundClassName, string $className, string $propertyName): self
     {
-        return new self(sprintf(self::CLASS_NOT_PARSED, $notFoundClassName, $className, $propertyName));
+        return new self(\sprintf(self::CLASS_NOT_PARSED, $notFoundClassName, $className, $propertyName));
     }
 }

--- a/src/Exception/RecursionException.php
+++ b/src/Exception/RecursionException.php
@@ -12,7 +12,7 @@ final class RecursionException extends SchemaException
 
     public static function forClass(string $className, RecursionContext $context): self
     {
-        return new self(sprintf(
+        return new self(\sprintf(
             self::FOR_CLASS,
             $className,
             (string) $context

--- a/src/Metadata/AbstractPropertyMetadata.php
+++ b/src/Metadata/AbstractPropertyMetadata.php
@@ -116,7 +116,7 @@ abstract class AbstractPropertyMetadata implements \JsonSerializable
     public function getCustomInformation(string $key): mixed
     {
         if (!\array_key_exists($key, $this->customInformation)) {
-            throw new \InvalidArgumentException(sprintf('Property %s has no custom information %s', $this->name, $key));
+            throw new \InvalidArgumentException(\sprintf('Property %s has no custom information %s', $this->name, $key));
         }
 
         return $this->customInformation[$key];

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -124,7 +124,7 @@ final class ClassMetadata implements \JsonSerializable
             }
         }
 
-        throw new \InvalidArgumentException(sprintf('Class %s has no constructor parameter called "%s"', $this->className, $name));
+        throw new \InvalidArgumentException(\sprintf('Class %s has no constructor parameter called "%s"', $this->className, $name));
     }
 
     /**

--- a/src/Metadata/ParameterMetadata.php
+++ b/src/Metadata/ParameterMetadata.php
@@ -58,7 +58,7 @@ final class ParameterMetadata implements \JsonSerializable
     public function getDefaultValue()
     {
         if ($this->required) {
-            throw new \BadMethodCallException(sprintf('Parameter %s is required and therefore has no default value', (string) $this));
+            throw new \BadMethodCallException(\sprintf('Parameter %s is required and therefore has no default value', (string) $this));
         }
 
         return $this->defaultValue;

--- a/src/Metadata/PropertyMetadata.php
+++ b/src/Metadata/PropertyMetadata.php
@@ -25,14 +25,14 @@ final class PropertyMetadata extends AbstractPropertyMetadata
     public function __construct(
         string $serializedName,
         string $name,
-        PropertyType $type = null,
+        ?PropertyType $type = null,
         bool $readOnly = true,
         bool $public = false,
-        VersionRange $versionRange = null,
+        ?VersionRange $versionRange = null,
         array $groups = [],
-        PropertyAccessor $accessor = null,
+        ?PropertyAccessor $accessor = null,
         array $customInformation = [],
-        int $maxDepth = null
+        ?int $maxDepth = null,
     ) {
         parent::__construct($name, $readOnly, $public);
         $this->serializedName = $serializedName;

--- a/src/Metadata/PropertyTypeClass.php
+++ b/src/Metadata/PropertyTypeClass.php
@@ -23,7 +23,7 @@ final class PropertyTypeClass extends AbstractPropertyType
     {
         parent::__construct($nullable);
         if (!self::isTypeCustomClass($className)) {
-            throw new InvalidTypeException(sprintf('Given type "%s" is not a custom class or interface but another supported type', $className));
+            throw new InvalidTypeException(\sprintf('Given type "%s" is not a custom class or interface but another supported type', $className));
         }
         if (!class_exists($className) && !interface_exists($className)) {
             throw InvalidTypeException::classNotFound($className);
@@ -75,10 +75,10 @@ final class PropertyTypeClass extends AbstractPropertyType
             return $other->merge($this);
         }
         if (!$other instanceof self) {
-            throw new \UnexpectedValueException(sprintf('Can\'t merge type %s with %s, they must be the same or unknown', self::class, \get_class($other)));
+            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with %s, they must be the same or unknown', self::class, \get_class($other)));
         }
         if ($this->getClassName() !== $other->getClassName()) {
-            throw new \UnexpectedValueException(sprintf('Can\'t merge type %s with %s, they must be equal', self::class, \get_class($other)));
+            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with %s, they must be equal', self::class, \get_class($other)));
         }
 
         return new self($this->className, $nullable);

--- a/src/Metadata/PropertyTypeDateTime.php
+++ b/src/Metadata/PropertyTypeDateTime.php
@@ -21,7 +21,7 @@ final class PropertyTypeDateTime extends AbstractPropertyType
      */
     private $dateTimeOptions;
 
-    public function __construct(bool $immutable, bool $nullable, DateTimeOptions $dateTimeOptions = null)
+    public function __construct(bool $immutable, bool $nullable, ?DateTimeOptions $dateTimeOptions = null)
     {
         parent::__construct($nullable);
         $this->immutable = $immutable;
@@ -108,10 +108,10 @@ final class PropertyTypeDateTime extends AbstractPropertyType
         return new self($this->immutable, $nullable, $options);
     }
 
-    public static function fromDateTimeClass(string $className, bool $nullable, DateTimeOptions $dateTimeOptions = null): self
+    public static function fromDateTimeClass(string $className, bool $nullable, ?DateTimeOptions $dateTimeOptions = null): self
     {
         if (!self::isTypeDateTime($className)) {
-            throw new \UnexpectedValueException(sprintf('Given type "%s" is not date time class or interface', $className));
+            throw new \UnexpectedValueException(\sprintf('Given type "%s" is not date time class or interface', $className));
         }
 
         return new self(\DateTimeImmutable::class === $className, $nullable, $dateTimeOptions);

--- a/src/Metadata/PropertyTypeIterable.php
+++ b/src/Metadata/PropertyTypeIterable.php
@@ -30,7 +30,7 @@ final class PropertyTypeIterable extends AbstractPropertyType
     /**
      * @param class-string<\Traversable>|null $traversableClass
      */
-    public function __construct(PropertyType $subType, bool $hashmap, bool $nullable, string $traversableClass = null)
+    public function __construct(PropertyType $subType, bool $hashmap, bool $nullable, ?string $traversableClass = null)
     {
         parent::__construct($nullable);
 
@@ -48,7 +48,7 @@ final class PropertyTypeIterable extends AbstractPropertyType
         $array = $this->isHashmap() ? '[string]' : '[]';
         if ($this->isTraversable()) {
             $collectionType = $this->isHashmap() ? ', string' : '';
-            $array .= sprintf('|\\%s<%s%s>', $this->traversableClass, $this->subType, $collectionType);
+            $array .= \sprintf('|\%s<%s%s>', $this->traversableClass, $this->subType, $collectionType);
         }
 
         return ((string) $this->subType).$array.parent::__toString();
@@ -109,7 +109,7 @@ final class PropertyTypeIterable extends AbstractPropertyType
             return new self($this->getSubType(), $this->isHashmap(), $nullable, $this->findCommonTraversableClass($thisTraversableClass, $other->getClassName()));
         }
         if (!$other instanceof self) {
-            throw new \UnexpectedValueException(sprintf('Can\'t merge type %s with %s, they must be the same or unknown', self::class, \get_class($other)));
+            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with %s, they must be the same or unknown', self::class, \get_class($other)));
         }
 
         /*
@@ -118,7 +118,7 @@ final class PropertyTypeIterable extends AbstractPropertyType
          * PHPDoc has no clear definition for hashmaps with string indexes, but JMS Serializer annotations do.
          */
         if ($this->isHashmap() && !$other->isHashmap()) {
-            throw new \UnexpectedValueException(sprintf('Can\'t merge type %s with %s, can\'t change hashmap into plain array', self::class, \get_class($other)));
+            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with %s, can\'t change hashmap into plain array', self::class, \get_class($other)));
         }
 
         $otherTraversableClass = $other->isTraversable() ? $other->getTraversableClass() : null;

--- a/src/Metadata/PropertyTypePrimitive.php
+++ b/src/Metadata/PropertyTypePrimitive.php
@@ -32,7 +32,7 @@ final class PropertyTypePrimitive extends AbstractPropertyType
             $typeName = self::TYPE_MAP[$typeName];
         }
         if (!self::isTypePrimitive($typeName)) {
-            throw new \UnexpectedValueException(sprintf('Given type "%s" is not primitive', $typeName));
+            throw new \UnexpectedValueException(\sprintf('Given type "%s" is not primitive', $typeName));
         }
         $this->typeName = $typeName;
     }
@@ -55,10 +55,10 @@ final class PropertyTypePrimitive extends AbstractPropertyType
             return new self($this->typeName, $nullable);
         }
         if (!$other instanceof self) {
-            throw new \UnexpectedValueException(sprintf('Can\'t merge type %s with %s, they must be the same or unknown', self::class, \get_class($other)));
+            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with %s, they must be the same or unknown', self::class, \get_class($other)));
         }
         if ($this->getTypeName() !== $other->getTypeName()) {
-            throw new \UnexpectedValueException(sprintf('Can\'t merge type %s with %s, they must be equal', self::class, \get_class($other)));
+            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with %s, they must be equal', self::class, \get_class($other)));
         }
 
         return new self($this->typeName, $nullable);

--- a/src/Metadata/PropertyTypeUnknown.php
+++ b/src/Metadata/PropertyTypeUnknown.php
@@ -19,7 +19,7 @@ final class PropertyTypeUnknown extends AbstractPropertyType
     public function merge(PropertyType $other): PropertyType
     {
         if (!$other instanceof self) {
-            throw new \UnexpectedValueException(sprintf('Can\'t merge type %s with %s, they must be the same', self::class, \get_class($other)));
+            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with %s, they must be the same', self::class, \get_class($other)));
         }
 
         return new self($this->isNullable() && $other->isNullable());

--- a/src/ModelParser/ParserContext.php
+++ b/src/ModelParser/ParserContext.php
@@ -33,7 +33,7 @@ final class ParserContext
             return $propertyMetadata->getName();
         }, $this->stack);
 
-        return sprintf('%s->%s', $this->root, implode('->', $stack));
+        return \sprintf('%s->%s', $this->root, implode('->', $stack));
     }
 
     public function push(PropertyVariationMetadata $property): self

--- a/src/ModelParser/RawMetadata/PropertyCollection.php
+++ b/src/ModelParser/RawMetadata/PropertyCollection.php
@@ -34,7 +34,7 @@ final class PropertyCollection implements \JsonSerializable
             return $name;
         }
 
-        return strtolower(preg_replace('/[A-Z]/', '_\\0', $name));
+        return strtolower(preg_replace('/[A-Z]/', '_\0', $name));
     }
 
     public static function useIdenticalNamingStrategy($value = true): void
@@ -106,7 +106,7 @@ final class PropertyCollection implements \JsonSerializable
     {
         $property = $this->findVariation($name);
         if (null === $property) {
-            throw new \UnexpectedValueException(sprintf('Property variation %s not found on PropertyCollection %s', $name, $this->serializedName));
+            throw new \UnexpectedValueException(\sprintf('Property variation %s not found on PropertyCollection %s', $name, $this->serializedName));
         }
 
         return $property;

--- a/src/ModelParser/RawMetadata/RawClassMetadata.php
+++ b/src/ModelParser/RawMetadata/RawClassMetadata.php
@@ -66,7 +66,7 @@ final class RawClassMetadata implements \JsonSerializable
     {
         $property = $this->findPropertyVariation($name);
         if (null === $property) {
-            throw new \UnexpectedValueException(sprintf('Property variation %s not found on class %s', $name, $this->className));
+            throw new \UnexpectedValueException(\sprintf('Property variation %s not found on class %s', $name, $this->className));
         }
 
         return $property;
@@ -105,14 +105,14 @@ final class RawClassMetadata implements \JsonSerializable
     public function renameProperty(string $propertyName, string $serializedName): void
     {
         if (!$this->hasPropertyCollection($propertyName)) {
-            throw new \UnexpectedValueException(sprintf('Property "%s::%s" not found to rename', (string) $this, $propertyName));
+            throw new \UnexpectedValueException(\sprintf('Property "%s::%s" not found to rename', (string) $this, $propertyName));
         }
         $prop = $this->getPropertyCollection($propertyName);
 
         if ($this->hasPropertyCollection($serializedName)) {
             $target = $this->getPropertyCollection($serializedName);
             if ($target === $prop) {
-                throw new \LogicException(sprintf('You can not rename %s into %s as it is the same property. Did you miss to handle camelCase properties with PropertyCollection::serializedName?', $propertyName, $serializedName));
+                throw new \LogicException(\sprintf('You can not rename %s into %s as it is the same property. Did you miss to handle camelCase properties with PropertyCollection::serializedName?', $propertyName, $serializedName));
             }
             foreach ($target->getVariations() as $variation) {
                 $prop->addVariation($variation);
@@ -120,7 +120,7 @@ final class RawClassMetadata implements \JsonSerializable
 
             $key = array_search($target, $this->properties, true);
             if (false === $key) {
-                throw new \RuntimeException(sprintf('This should not be possible: Target property %s found but then not found $this->properties. While renaming from %s::%s', $serializedName, $this->getClassName(), $propertyName));
+                throw new \RuntimeException(\sprintf('This should not be possible: Target property %s found but then not found $this->properties. While renaming from %s::%s', $serializedName, $this->getClassName(), $propertyName));
             }
             unset($this->properties[$key]);
         }
@@ -174,7 +174,7 @@ final class RawClassMetadata implements \JsonSerializable
     {
         $property = $this->findPropertyCollection($serializedName);
         if (null === $property) {
-            throw new \UnexpectedValueException(sprintf('Property collection %s not found on class %s', $serializedName, $this->className));
+            throw new \UnexpectedValueException(\sprintf('Property collection %s not found on class %s', $serializedName, $this->className));
         }
 
         return $property;
@@ -186,7 +186,7 @@ final class RawClassMetadata implements \JsonSerializable
     public function addPropertyCollection(PropertyCollection $property): void
     {
         if ($this->hasPropertyCollection($property->getSerializedName())) {
-            throw new \UnexpectedValueException(sprintf('Property "%s" is already defined on model %s, cannot add it twice', (string) $property, (string) $this));
+            throw new \UnexpectedValueException(\sprintf('Property "%s" is already defined on model %s, cannot add it twice', (string) $property, (string) $this));
         }
 
         $this->properties[] = $property;

--- a/src/RawClassMetadataRegistry.php
+++ b/src/RawClassMetadataRegistry.php
@@ -16,7 +16,7 @@ final class RawClassMetadataRegistry
     public function add(RawClassMetadata $classMetadata): void
     {
         if ($this->contains($classMetadata->getClassName())) {
-            throw new \BadMethodCallException(sprintf('The model for "%s" is already in the registry', $classMetadata->getClassName()));
+            throw new \BadMethodCallException(\sprintf('The model for "%s" is already in the registry', $classMetadata->getClassName()));
         }
 
         $this->classMetadata[$classMetadata->getClassName()] = $classMetadata;

--- a/src/RecursionChecker.php
+++ b/src/RecursionChecker.php
@@ -45,7 +45,7 @@ final class RecursionChecker
      *
      * @param string[][] $expectedRecursions List of expected recursions
      */
-    public function __construct(LoggerInterface $logger = null, array $expectedRecursions = [])
+    public function __construct(?LoggerInterface $logger = null, array $expectedRecursions = [])
     {
         $this->logger = $logger;
         $this->expectedRecursions = $expectedRecursions;

--- a/src/RecursionContext.php
+++ b/src/RecursionContext.php
@@ -37,7 +37,7 @@ final class RecursionContext
             return $propertyMetadata->getSerializedName();
         }, $this->stack);
 
-        return sprintf('%s->%s', $this->root, implode('->', $stack));
+        return \sprintf('%s->%s', $this->root, implode('->', $stack));
     }
 
     public function push(PropertyMetadata $property): self

--- a/src/TypeParser/JMSTypeParser.php
+++ b/src/TypeParser/JMSTypeParser.php
@@ -80,7 +80,7 @@ final class JMSTypeParser
                 return new PropertyTypeIterable($this->parseType($typeInfo['params'][1], true), true, $nullable, $traversableClass);
             }
 
-            throw new InvalidTypeException(sprintf('JMS property type array can\'t have more than 2 parameters (%s)', var_export($typeInfo, true)));
+            throw new InvalidTypeException(\sprintf('JMS property type array can\'t have more than 2 parameters (%s)', var_export($typeInfo, true)));
         }
 
         if (PropertyTypeDateTime::isTypeDateTime($typeInfo['name']) || (self::TYPE_DATETIME_INTERFACE === $typeInfo['name'])) {
@@ -104,7 +104,7 @@ final class JMSTypeParser
             );
         }
 
-        throw new InvalidTypeException(sprintf('Unknown JMS property found (%s)', var_export($typeInfo, true)));
+        throw new InvalidTypeException(\sprintf('Unknown JMS property found (%s)', var_export($typeInfo, true)));
     }
 
     private function getTraversableClass(string $name): ?string

--- a/src/TypeParser/PhpTypeParser.php
+++ b/src/TypeParser/PhpTypeParser.php
@@ -71,7 +71,7 @@ final class PhpTypeParser
             return new PropertyTypeUnknown($nullable);
         }
         if (\count($filteredTypes) > 1) {
-            throw new InvalidTypeException(sprintf('Multiple types are not supported (%s)', $rawType));
+            throw new InvalidTypeException(\sprintf('Multiple types are not supported (%s)', $rawType));
         }
 
         return $this->createType($filteredTypes[0], $nullable, $declaringClass, $traversableClass);
@@ -86,10 +86,10 @@ final class PhpTypeParser
             return $this->createType($reflType->getName(), $reflType->allowsNull());
         }
 
-        throw new InvalidTypeException(sprintf('No type information found, got %s but expected %s', \ReflectionType::class, \ReflectionNamedType::class));
+        throw new InvalidTypeException(\sprintf('No type information found, got %s but expected %s', \ReflectionType::class, \ReflectionNamedType::class));
     }
 
-    private function createType(string $rawType, bool $nullable, \ReflectionClass $reflClass = null, string $traversableClass = null): PropertyType
+    private function createType(string $rawType, bool $nullable, ?\ReflectionClass $reflClass = null, ?string $traversableClass = null): PropertyType
     {
         if (self::TYPE_ARRAY === $rawType) {
             return new PropertyTypeIterable(new PropertyTypeUnknown(false), false, $nullable);
@@ -123,7 +123,7 @@ final class PhpTypeParser
         return new PropertyTypeClass($resolvedClass, $nullable);
     }
 
-    private function resolveClass(string $className, \ReflectionClass $reflClass = null): string
+    private function resolveClass(string $className, ?\ReflectionClass $reflClass = null): string
     {
         // leading backslash means absolute class name
         if (0 === strpos($className, '\\')) {

--- a/tests/Metadata/PropertyTypeTest.php
+++ b/tests/Metadata/PropertyTypeTest.php
@@ -142,7 +142,7 @@ class PropertyTypeTest extends TestCase
 
                 try {
                     $typeA->merge($typeB);
-                    $this->fail(sprintf('Merge of %s into %s should not be possible', (string) $typeB, (string) $typeA));
+                    $this->fail(\sprintf('Merge of %s into %s should not be possible', (string) $typeB, (string) $typeA));
                 } catch (\UnexpectedValueException $e) {
                     $this->assertStringContainsString('merge', $e->getMessage());
                 }

--- a/tests/TypeParser/JMSTypeParserTest.php
+++ b/tests/TypeParser/JMSTypeParserTest.php
@@ -97,7 +97,7 @@ class JMSTypeParserTest extends TestCase
     /**
      * @dataProvider provideTypeCases
      */
-    public function testType(string $rawType, string $expectedType, bool $expectedNullable = null): void
+    public function testType(string $rawType, string $expectedType, ?bool $expectedNullable = null): void
     {
         $type = $this->parser->parse($rawType);
 

--- a/tests/TypeParser/PhpTypeParserTest.php
+++ b/tests/TypeParser/PhpTypeParserTest.php
@@ -149,7 +149,7 @@ class PhpTypeParserTest extends TestCase
     /**
      * @dataProvider providePropertyTypeCases
      */
-    public function testPropertyType(string $rawType, string $expectedType, bool $expectedNullable = null): void
+    public function testPropertyType(string $rawType, string $expectedType, ?bool $expectedNullable = null): void
     {
         $type = $this->parser->parseAnnotationType($rawType, new \ReflectionClass($this));
 
@@ -259,7 +259,7 @@ class PhpTypeParserTest extends TestCase
     /**
      * @dataProvider provideReflectionTypeCases
      */
-    public function testReflectionType(\ReflectionType $reflType, string $expectedType, bool $expectedNullable = null): void
+    public function testReflectionType(\ReflectionType $reflType, string $expectedType, ?bool $expectedNullable = null): void
     {
         $type = $this->parser->parseReflectionType($reflType);
 


### PR DESCRIPTION
PHP 8.4 deprecated types that are implicitly marked as nullable so the following should be changed 👇 

```php
function foo(string $string = null) {}
// becomes
function foo(?string $string = null) {}
```

To fix this in the current code, I updated `php-cs-fixer` to the latest version `v3.68.1` which also includes the [nullable_type_declaration_for_default_null_value](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/7732e209dcf1a86d0f268faf399506054ee96275/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.rst) rule that takes care of this change.

The second commit contains all the changes that were done by executing `composer cs-fixer`