### PR TITLE
Decouple property naming from PropertyCollection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 * Adjusted code to not trigger warnings with PHP 8.4
 * Removed deprecated `getDeserializeFormat` method from date time
 * Replaced `@Preferred` annotation with the `#[Preferred]` attribute
+* Added a new `PropertyNamingStrategyInterface`  which can be used to modify the naming strategy for properties. Previously 
+  this could be adjusted via the `PropertyCollection::useIdenticalNamingStrategy` method, but as this was a bit error prone, a separate
+  interface was introduced. This new interface also comes with two implementations: 
+  * `IdenticalPropertyNamingStrategy` 
+  * `SnakeCasePropertyNamingStrategy`.
 
 # Version 1.x
 

--- a/README.md
+++ b/README.md
@@ -94,12 +94,24 @@ is validated to not contain any infinite recursion.
 
 By default, property names will be translated from a camelCased to a lower and 
 snake_cased name (e.g. `myProperty` becomes `my_property`). If you want to keep
-the property name as is, you can change the strategy to `identical` via the 
-following code:
+the property name as is, you can change the strategy to `identical` by passing
+the corresponding strategy to the parser you are using.
+
+For the `JMSParser`, it would look like this:
 
 ```php
-\Liip\MetadataParser\ModelParser\RawMetadata\PropertyCollection::useIdenticalNamingStrategy();
+use Doctrine\Common\Annotations\AnnotationReader;
+use Liip\MetadataParser\Builder;
+use Liip\MetadataParser\ModelParser\JMSParser;
+use Liip\MetadataParser\ModelParser\NamingStrategy\IdenticalPropertyNamingStrategy;
+
+$identicalNamingStrategy = new IdenticalPropertyNamingStrategy();
+
+$parser = new JMSParser(new AnnotationReader(), $identicalNamingStrategy);
+$builder = new Builder($parser)
 ```
+
+You can also create your own naming strategy by implementing the `Liip\MetadataParser\ModelParser\NamingStrategy\PropertyNamingStrategyInterface`
 
 ### Handling Edge Cases with @Preferred
 

--- a/README.md
+++ b/README.md
@@ -95,19 +95,21 @@ is validated to not contain any infinite recursion.
 By default, property names will be translated from a camelCased to a lower and 
 snake_cased name (e.g. `myProperty` becomes `my_property`). If you want to keep
 the property name as is, you can change the strategy to `identical` by passing
-the corresponding strategy to the parser you are using.
-
-For the `JMSParser`, it would look like this:
+the corresponding strategy to the parser.
 
 ```php
-use Doctrine\Common\Annotations\AnnotationReader;
 use Liip\MetadataParser\Builder;
-use Liip\MetadataParser\ModelParser\JMSParser;
 use Liip\MetadataParser\ModelParser\NamingStrategy\IdenticalPropertyNamingStrategy;
 
 $identicalNamingStrategy = new IdenticalPropertyNamingStrategy();
 
-$parser = new JMSParser(new AnnotationReader(), $identicalNamingStrategy);
+$parser = new Parser(
+    [
+        // your parsers
+    ],
+    new IdenticalPropertyNamingStrategy()
+);
+
 $builder = new Builder($parser)
 ```
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -21,15 +21,9 @@ use Liip\MetadataParser\Reducer\PropertyReducerInterface;
  */
 final class Builder
 {
-    /**
-     * @var Parser
-     */
-    private $parser;
+    private Parser $parser;
 
-    /**
-     * @var RecursionChecker
-     */
-    private $recursionChecker;
+    private RecursionChecker $recursionChecker;
 
     public function __construct(Parser $parser, RecursionChecker $recursionChecker)
     {

--- a/src/ModelParser/JMSParser.php
+++ b/src/ModelParser/JMSParser.php
@@ -33,7 +33,6 @@ use Liip\MetadataParser\Metadata\PropertyAccessor;
 use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
 use Liip\MetadataParser\ModelParser\NamingStrategy\PropertyNamingStrategyInterface;
-use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyCollection;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
@@ -57,19 +56,15 @@ final class JMSParser implements ModelParserInterface
 
     private Reader $annotationOrAttributeReader;
 
-    private PropertyNamingStrategyInterface $namingStrategy;
-
-    public function __construct(Reader $reader, ?PropertyNamingStrategyInterface $namingStrategy = null)
+    public function __construct(Reader $reader)
     {
         $this->annotationOrAttributeReader = new AttributeReader($reader);
 
         $this->phpTypeParser = new PhpTypeParser();
         $this->jmsTypeParser = new JMSTypeParser();
-
-        $this->namingStrategy = $namingStrategy ?? new SnakeCasePropertyNamingStrategy();
     }
 
-    public function parse(RawClassMetadata $classMetadata): void
+    public function parse(RawClassMetadata $classMetadata, PropertyNamingStrategyInterface $propertyNamingStrategy): void
     {
         try {
             $reflClass = new \ReflectionClass($classMetadata->getClassName());
@@ -78,7 +73,7 @@ final class JMSParser implements ModelParserInterface
         }
 
         try {
-            $this->parseProperties($reflClass, $classMetadata);
+            $this->parseProperties($reflClass, $classMetadata, $propertyNamingStrategy);
             $this->parseMethods($reflClass, $classMetadata);
             $this->parseClass($reflClass, $classMetadata);
         } catch (SyntaxError $exception) {
@@ -86,10 +81,10 @@ final class JMSParser implements ModelParserInterface
         }
     }
 
-    private function parseProperties(\ReflectionClass $reflClass, RawClassMetadata $classMetadata): void
+    private function parseProperties(\ReflectionClass $reflClass, RawClassMetadata $classMetadata, PropertyNamingStrategyInterface $propertyNamingStrategy): void
     {
         if ($reflParentClass = $reflClass->getParentClass()) {
-            $this->parseProperties($reflParentClass, $classMetadata);
+            $this->parseProperties($reflParentClass, $classMetadata, $propertyNamingStrategy);
         }
 
         foreach ($reflClass->getProperties() as $reflProperty) {
@@ -99,7 +94,7 @@ final class JMSParser implements ModelParserInterface
                 throw ParseException::propertyError((string) $classMetadata, $reflProperty->getName(), $e);
             }
 
-            $property = $this->getProperty($classMetadata, $reflProperty, $attributes);
+            $property = $this->getProperty($classMetadata, $reflProperty, $attributes, $propertyNamingStrategy);
             $this->parsePropertyAttributes($classMetadata, $property, $attributes);
         }
     }
@@ -296,9 +291,9 @@ final class JMSParser implements ModelParserInterface
      * If the property already exists on the class metadata this is returned.
      * If the property has a serialized name that overrides the name of an existing property, it will be renamed and merged.
      */
-    private function getProperty(RawClassMetadata $classMetadata, \ReflectionProperty $reflProperty, array $attributes): PropertyVariationMetadata
+    private function getProperty(RawClassMetadata $classMetadata, \ReflectionProperty $reflProperty, array $attributes, PropertyNamingStrategyInterface $propertyNamingStrategy): PropertyVariationMetadata
     {
-        $defaultName = $this->namingStrategy->getSerializedName($reflProperty->getName());
+        $defaultName = $propertyNamingStrategy->getSerializedName($reflProperty->getName());
         $serializedName = $this->getSerializedName($attributes) ?: $defaultName;
         if ($classMetadata->hasPropertyVariation($reflProperty->getName())) {
             $property = $classMetadata->getPropertyVariation($reflProperty->getName());

--- a/src/ModelParser/JMSParser.php
+++ b/src/ModelParser/JMSParser.php
@@ -32,6 +32,8 @@ use Liip\MetadataParser\Exception\ParseException;
 use Liip\MetadataParser\Metadata\PropertyAccessor;
 use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
+use Liip\MetadataParser\ModelParser\NamingStrategy\PropertyNamingStrategyInterface;
+use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyCollection;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
@@ -55,12 +57,16 @@ final class JMSParser implements ModelParserInterface
 
     private Reader $annotationOrAttributeReader;
 
-    public function __construct(Reader $reader)
+    private PropertyNamingStrategyInterface $namingStrategy;
+
+    public function __construct(Reader $reader, ?PropertyNamingStrategyInterface $namingStrategy = null)
     {
         $this->annotationOrAttributeReader = new AttributeReader($reader);
 
         $this->phpTypeParser = new PhpTypeParser();
         $this->jmsTypeParser = new JMSTypeParser();
+
+        $this->namingStrategy = $namingStrategy ?? new SnakeCasePropertyNamingStrategy();
     }
 
     public function parse(RawClassMetadata $classMetadata): void
@@ -292,16 +298,16 @@ final class JMSParser implements ModelParserInterface
      */
     private function getProperty(RawClassMetadata $classMetadata, \ReflectionProperty $reflProperty, array $attributes): PropertyVariationMetadata
     {
-        $defaultName = PropertyCollection::serializedName($reflProperty->getName());
-        $name = $this->getSerializedName($attributes) ?: $defaultName;
+        $defaultName = $this->namingStrategy->getSerializedName($reflProperty->getName());
+        $serializedName = $this->getSerializedName($attributes) ?: $defaultName;
         if ($classMetadata->hasPropertyVariation($reflProperty->getName())) {
             $property = $classMetadata->getPropertyVariation($reflProperty->getName());
-            if ($defaultName !== $name && $classMetadata->hasPropertyCollection($defaultName)) {
-                $classMetadata->renameProperty($defaultName, $name);
+            if ($defaultName !== $serializedName && $classMetadata->hasPropertyCollection($defaultName)) {
+                $classMetadata->renameProperty($reflProperty->getName(), $serializedName);
             }
         } else {
             $property = PropertyVariationMetadata::fromReflection($reflProperty);
-            $classMetadata->addPropertyVariation($name, $property);
+            $classMetadata->addPropertyVariation($serializedName, $property);
         }
 
         return $property;

--- a/src/ModelParser/LiipMetadataAttributeParser.php
+++ b/src/ModelParser/LiipMetadataAttributeParser.php
@@ -6,6 +6,7 @@ namespace Liip\MetadataParser\ModelParser;
 
 use Liip\MetadataParser\Attribute\Preferred;
 use Liip\MetadataParser\Exception\ParseException;
+use Liip\MetadataParser\ModelParser\NamingStrategy\PropertyNamingStrategyInterface;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
 
@@ -19,7 +20,7 @@ use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
  */
 final class LiipMetadataAttributeParser implements ModelParserInterface
 {
-    public function parse(RawClassMetadata $classMetadata): void
+    public function parse(RawClassMetadata $classMetadata, PropertyNamingStrategyInterface $propertyNamingStrategy): void
     {
         try {
             $reflClass = new \ReflectionClass($classMetadata->getClassName());

--- a/src/ModelParser/ModelParserInterface.php
+++ b/src/ModelParser/ModelParserInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Liip\MetadataParser\ModelParser;
 
 use Liip\MetadataParser\Exception\ParseException;
+use Liip\MetadataParser\ModelParser\NamingStrategy\PropertyNamingStrategyInterface;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
 
 interface ModelParserInterface
@@ -12,5 +13,5 @@ interface ModelParserInterface
     /**
      * @throws ParseException
      */
-    public function parse(RawClassMetadata $classMetadata): void;
+    public function parse(RawClassMetadata $classMetadata, PropertyNamingStrategyInterface $propertyNamingStrategy): void;
 }

--- a/src/ModelParser/NamingStrategy/IdenticalPropertyNamingStrategy.php
+++ b/src/ModelParser/NamingStrategy/IdenticalPropertyNamingStrategy.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liip\MetadataParser\ModelParser\NamingStrategy;
+
+final class IdenticalPropertyNamingStrategy implements PropertyNamingStrategyInterface
+{
+    public function getSerializedName(string $name): string
+    {
+        return $name;
+    }
+}

--- a/src/ModelParser/NamingStrategy/PropertyNamingStrategyInterface.php
+++ b/src/ModelParser/NamingStrategy/PropertyNamingStrategyInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liip\MetadataParser\ModelParser\NamingStrategy;
+
+interface PropertyNamingStrategyInterface
+{
+    public function getSerializedName(string $name): string;
+}

--- a/src/ModelParser/NamingStrategy/SnakeCasePropertyNamingStrategy.php
+++ b/src/ModelParser/NamingStrategy/SnakeCasePropertyNamingStrategy.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liip\MetadataParser\ModelParser\NamingStrategy;
+
+final class SnakeCasePropertyNamingStrategy implements PropertyNamingStrategyInterface
+{
+    public function getSerializedName(string $name): string
+    {
+        return strtolower(preg_replace('/[A-Z]/', '_\0', $name));
+    }
+}

--- a/src/ModelParser/PhpDocParser.php
+++ b/src/ModelParser/PhpDocParser.php
@@ -8,7 +8,6 @@ use Liip\MetadataParser\Exception\ParseException;
 use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
 use Liip\MetadataParser\ModelParser\NamingStrategy\PropertyNamingStrategyInterface;
-use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyCollection;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
@@ -21,16 +20,12 @@ final class PhpDocParser implements ModelParserInterface
      */
     private $typeParser;
 
-    private PropertyNamingStrategyInterface $namingStrategy;
-
-    public function __construct(?PropertyNamingStrategyInterface $namingStrategy = null)
+    public function __construct()
     {
         $this->typeParser = new PhpTypeParser();
-
-        $this->namingStrategy = $namingStrategy ?? new SnakeCasePropertyNamingStrategy();
     }
 
-    public function parse(RawClassMetadata $classMetadata): void
+    public function parse(RawClassMetadata $classMetadata, PropertyNamingStrategyInterface $propertyNamingStrategy): void
     {
         try {
             $reflClass = new \ReflectionClass($classMetadata->getClassName());
@@ -38,13 +33,13 @@ final class PhpDocParser implements ModelParserInterface
             throw ParseException::classNotFound($classMetadata->getClassName(), $e);
         }
 
-        $this->parseProperties($reflClass, $classMetadata);
+        $this->parseProperties($reflClass, $classMetadata, $propertyNamingStrategy);
     }
 
     /**
      * @return string[] the property names that have been added
      */
-    private function parseProperties(\ReflectionClass $reflClass, RawClassMetadata $classMetadata): array
+    private function parseProperties(\ReflectionClass $reflClass, RawClassMetadata $classMetadata, PropertyNamingStrategyInterface $propertyNamingStrategy): array
     {
         $existingProperties = array_map(static function (PropertyCollection $prop): string {
             return (string) $prop;
@@ -53,7 +48,7 @@ final class PhpDocParser implements ModelParserInterface
         $addedProperties = [];
         $parentProperties = [];
         if ($reflParentClass = $reflClass->getParentClass()) {
-            $parentProperties = $this->parseProperties($reflParentClass, $classMetadata);
+            $parentProperties = $this->parseProperties($reflParentClass, $classMetadata, $propertyNamingStrategy);
         }
         $parentPropertiesLookup = array_flip($parentProperties);
 
@@ -61,7 +56,7 @@ final class PhpDocParser implements ModelParserInterface
             if ($classMetadata->hasPropertyVariation($reflProperty->getName())) {
                 $property = $classMetadata->getPropertyVariation($reflProperty->getName());
             } else {
-                $serializedName = $this->namingStrategy->getSerializedName($reflProperty->getName());
+                $serializedName = $propertyNamingStrategy->getSerializedName($reflProperty->getName());
                 $property = PropertyVariationMetadata::fromReflection($reflProperty);
                 $classMetadata->addPropertyVariation($serializedName, $property);
             }

--- a/src/ModelParser/PhpDocParser.php
+++ b/src/ModelParser/PhpDocParser.php
@@ -7,6 +7,8 @@ namespace Liip\MetadataParser\ModelParser;
 use Liip\MetadataParser\Exception\ParseException;
 use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
+use Liip\MetadataParser\ModelParser\NamingStrategy\PropertyNamingStrategyInterface;
+use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyCollection;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
@@ -19,9 +21,13 @@ final class PhpDocParser implements ModelParserInterface
      */
     private $typeParser;
 
-    public function __construct()
+    private PropertyNamingStrategyInterface $namingStrategy;
+
+    public function __construct(?PropertyNamingStrategyInterface $namingStrategy = null)
     {
         $this->typeParser = new PhpTypeParser();
+
+        $this->namingStrategy = $namingStrategy ?? new SnakeCasePropertyNamingStrategy();
     }
 
     public function parse(RawClassMetadata $classMetadata): void
@@ -55,8 +61,9 @@ final class PhpDocParser implements ModelParserInterface
             if ($classMetadata->hasPropertyVariation($reflProperty->getName())) {
                 $property = $classMetadata->getPropertyVariation($reflProperty->getName());
             } else {
+                $serializedName = $this->namingStrategy->getSerializedName($reflProperty->getName());
                 $property = PropertyVariationMetadata::fromReflection($reflProperty);
-                $classMetadata->addPropertyVariation($reflProperty->getName(), $property);
+                $classMetadata->addPropertyVariation($serializedName, $property);
             }
 
             $docComment = $reflProperty->getDocComment();

--- a/src/ModelParser/RawMetadata/PropertyCollection.php
+++ b/src/ModelParser/RawMetadata/PropertyCollection.php
@@ -6,8 +6,6 @@ namespace Liip\MetadataParser\ModelParser\RawMetadata;
 
 final class PropertyCollection implements \JsonSerializable
 {
-    private static $identicalNamingStrategy = false;
-
     /**
      * @var string
      */
@@ -16,7 +14,7 @@ final class PropertyCollection implements \JsonSerializable
     /**
      * @var PropertyVariationMetadata[]
      */
-    private $variations = [];
+    private array $variations = [];
 
     public function __construct(string $name)
     {
@@ -26,20 +24,6 @@ final class PropertyCollection implements \JsonSerializable
     public function __toString(): string
     {
         return $this->serializedName;
-    }
-
-    public static function serializedName(string $name): string
-    {
-        if (self::$identicalNamingStrategy) {
-            return $name;
-        }
-
-        return strtolower(preg_replace('/[A-Z]/', '_\0', $name));
-    }
-
-    public static function useIdenticalNamingStrategy($value = true): void
-    {
-        self::$identicalNamingStrategy = $value;
     }
 
     /**
@@ -71,7 +55,7 @@ final class PropertyCollection implements \JsonSerializable
 
     public function setSerializedName(string $name): void
     {
-        $this->serializedName = self::serializedName($name);
+        $this->serializedName = $name;
     }
 
     public function getSerializedName(): string

--- a/src/ModelParser/RawMetadata/RawClassMetadata.php
+++ b/src/ModelParser/RawMetadata/RawClassMetadata.php
@@ -104,10 +104,11 @@ final class RawClassMetadata implements \JsonSerializable
      */
     public function renameProperty(string $propertyName, string $serializedName): void
     {
-        if (!$this->hasPropertyCollection($propertyName)) {
+        if (!$this->hasPropertyVariation($propertyName)) {
             throw new \UnexpectedValueException(\sprintf('Property "%s::%s" not found to rename', (string) $this, $propertyName));
         }
-        $prop = $this->getPropertyCollection($propertyName);
+
+        $prop = $this->getPropertyCollectionByPropertyVariation($propertyName);
 
         if ($this->hasPropertyCollection($serializedName)) {
             $target = $this->getPropertyCollection($serializedName);
@@ -192,6 +193,25 @@ final class RawClassMetadata implements \JsonSerializable
         $this->properties[] = $property;
     }
 
+    public function hasPropertyCollectionWithPropertyVariation(string $name): bool
+    {
+        return null !== $this->findPropertyCollectionByPropertyVariation($name);
+    }
+
+    /**
+     * @throws \UnexpectedValueException if no variation with this name exists
+     */
+    public function getPropertyCollectionByPropertyVariation(string $name): PropertyCollection
+    {
+        foreach ($this->properties as $prop) {
+            if ($prop->hasVariation($name)) {
+                return $prop;
+            }
+        }
+
+        throw new \UnexpectedValueException(\sprintf('Property collection for variation %s not found on class %s', $name, $this->className));
+    }
+
     /**
      * Usort the properties with this callable.
      */
@@ -238,9 +258,8 @@ final class RawClassMetadata implements \JsonSerializable
 
     private function findPropertyCollection(string $name): ?PropertyCollection
     {
-        $serializedName = PropertyCollection::serializedName($name);
         foreach ($this->properties as $property) {
-            if ($property->getSerializedName() === $serializedName) {
+            if ($property->getSerializedName() === $name) {
                 return $property;
             }
         }
@@ -253,6 +272,17 @@ final class RawClassMetadata implements \JsonSerializable
         foreach ($this->properties as $prop) {
             if ($prop->hasVariation($name)) {
                 return $prop->getVariation($name);
+            }
+        }
+
+        return null;
+    }
+
+    public function findPropertyCollectionByPropertyVariation(string $name): ?PropertyCollection
+    {
+        foreach ($this->properties as $prop) {
+            if ($prop->hasVariation($name)) {
+                return $prop;
             }
         }
 

--- a/src/ModelParser/ReflectionParser.php
+++ b/src/ModelParser/ReflectionParser.php
@@ -7,7 +7,6 @@ namespace Liip\MetadataParser\ModelParser;
 use Liip\MetadataParser\Exception\ParseException;
 use Liip\MetadataParser\Metadata\ParameterMetadata;
 use Liip\MetadataParser\ModelParser\NamingStrategy\PropertyNamingStrategyInterface;
-use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
 use Liip\MetadataParser\TypeParser\PhpTypeParser;
@@ -26,17 +25,13 @@ final class ReflectionParser implements ModelParserInterface
      */
     private $reflectionSupportsPropertyType;
 
-    private PropertyNamingStrategyInterface $namingStrategy;
-
-    public function __construct(?PropertyNamingStrategyInterface $namingStrategy = null)
+    public function __construct()
     {
         $this->typeParser = new PhpTypeParser();
         $this->reflectionSupportsPropertyType = version_compare(\PHP_VERSION, '7.4', '>=');
-
-        $this->namingStrategy = $namingStrategy ?? new SnakeCasePropertyNamingStrategy();
     }
 
-    public function parse(RawClassMetadata $classMetadata): void
+    public function parse(RawClassMetadata $classMetadata, PropertyNamingStrategyInterface $propertyNamingStrategy): void
     {
         try {
             $reflClass = new \ReflectionClass($classMetadata->getClassName());
@@ -44,14 +39,14 @@ final class ReflectionParser implements ModelParserInterface
             throw ParseException::classNotFound($classMetadata->getClassName(), $e);
         }
 
-        $this->parseProperties($reflClass, $classMetadata);
+        $this->parseProperties($reflClass, $classMetadata, $propertyNamingStrategy);
         $this->parseConstructor($reflClass, $classMetadata);
     }
 
-    private function parseProperties(\ReflectionClass $reflClass, RawClassMetadata $classMetadata): void
+    private function parseProperties(\ReflectionClass $reflClass, RawClassMetadata $classMetadata, PropertyNamingStrategyInterface $propertyNamingStrategy): void
     {
         if ($reflParentClass = $reflClass->getParentClass()) {
-            $this->parseProperties($reflParentClass, $classMetadata);
+            $this->parseProperties($reflParentClass, $classMetadata, $propertyNamingStrategy);
         }
 
         foreach ($reflClass->getProperties() as $reflProperty) {
@@ -74,7 +69,7 @@ final class ReflectionParser implements ModelParserInterface
                 if ($type) {
                     $property->setType($type);
                 }
-                $serializedName = $this->namingStrategy->getSerializedName($reflProperty->getName());
+                $serializedName = $propertyNamingStrategy->getSerializedName($reflProperty->getName());
                 $classMetadata->addPropertyVariation($serializedName, $property);
             }
         }

--- a/src/ModelParser/ReflectionParser.php
+++ b/src/ModelParser/ReflectionParser.php
@@ -6,6 +6,8 @@ namespace Liip\MetadataParser\ModelParser;
 
 use Liip\MetadataParser\Exception\ParseException;
 use Liip\MetadataParser\Metadata\ParameterMetadata;
+use Liip\MetadataParser\ModelParser\NamingStrategy\PropertyNamingStrategyInterface;
+use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
 use Liip\MetadataParser\TypeParser\PhpTypeParser;
@@ -24,10 +26,14 @@ final class ReflectionParser implements ModelParserInterface
      */
     private $reflectionSupportsPropertyType;
 
-    public function __construct()
+    private PropertyNamingStrategyInterface $namingStrategy;
+
+    public function __construct(?PropertyNamingStrategyInterface $namingStrategy = null)
     {
         $this->typeParser = new PhpTypeParser();
         $this->reflectionSupportsPropertyType = version_compare(\PHP_VERSION, '7.4', '>=');
+
+        $this->namingStrategy = $namingStrategy ?? new SnakeCasePropertyNamingStrategy();
     }
 
     public function parse(RawClassMetadata $classMetadata): void
@@ -68,7 +74,8 @@ final class ReflectionParser implements ModelParserInterface
                 if ($type) {
                     $property->setType($type);
                 }
-                $classMetadata->addPropertyVariation($reflProperty->getName(), $property);
+                $serializedName = $this->namingStrategy->getSerializedName($reflProperty->getName());
+                $classMetadata->addPropertyVariation($serializedName, $property);
             }
         }
     }

--- a/src/ModelParser/VisibilityAwarePropertyAccessGuesser.php
+++ b/src/ModelParser/VisibilityAwarePropertyAccessGuesser.php
@@ -6,6 +6,7 @@ namespace Liip\MetadataParser\ModelParser;
 
 use Liip\MetadataParser\Exception\ParseException;
 use Liip\MetadataParser\Metadata\PropertyAccessor;
+use Liip\MetadataParser\ModelParser\NamingStrategy\PropertyNamingStrategyInterface;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
 
@@ -21,7 +22,7 @@ use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
  */
 class VisibilityAwarePropertyAccessGuesser implements ModelParserInterface
 {
-    public function parse(RawClassMetadata $classMetadata): void
+    public function parse(RawClassMetadata $classMetadata, PropertyNamingStrategyInterface $propertyNamingStrategy): void
     {
         try {
             $reflClass = new \ReflectionClass($classMetadata->getClassName());

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -8,6 +8,8 @@ use Liip\MetadataParser\Exception\ParseException;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
 use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\ModelParser\ModelParserInterface;
+use Liip\MetadataParser\ModelParser\NamingStrategy\PropertyNamingStrategyInterface;
+use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\ParserContext;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
 
@@ -16,14 +18,17 @@ final class Parser
     /**
      * @var ModelParserInterface[]
      */
-    private $parsers;
+    private array $parsers;
+
+    private PropertyNamingStrategyInterface $propertyNamingStrategy;
 
     /**
      * @param ModelParserInterface[] $parsers
      */
-    public function __construct(array $parsers)
+    public function __construct(array $parsers, ?PropertyNamingStrategyInterface $propertyNamingStrategy = null)
     {
         $this->parsers = $parsers;
+        $this->propertyNamingStrategy = $propertyNamingStrategy ?? new SnakeCasePropertyNamingStrategy();
     }
 
     /**
@@ -48,7 +53,7 @@ final class Parser
 
         $rawClassMetadata = new RawClassMetadata($className);
         foreach ($this->parsers as $parser) {
-            $parser->parse($rawClassMetadata);
+            $parser->parse($rawClassMetadata, $this->propertyNamingStrategy);
         }
         $registry->add($rawClassMetadata);
 

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Liip\MetadataParser;
 
+use Doctrine\Common\Annotations\AnnotationReader;
+use JMS\Serializer\Annotation\SerializedName;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\Metadata\PropertyMetadata;
 use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
+use Liip\MetadataParser\ModelParser\JMSParser;
 use Liip\MetadataParser\ModelParser\PhpDocParser;
 use Liip\MetadataParser\ModelParser\ReflectionParser;
 use Liip\MetadataParser\Parser;
@@ -21,10 +24,7 @@ use Tests\Liip\MetadataParser\ModelParser\Model\Nested;
  */
 class BuilderTest extends TestCase
 {
-    /**
-     * @var Builder
-     */
-    private $builder;
+    private Builder $builder;
 
     protected function setUp(): void
     {
@@ -32,6 +32,7 @@ class BuilderTest extends TestCase
             [
                 new ReflectionParser(),
                 new PhpDocParser(),
+                new JMSParser(new AnnotationReader()),
             ]
         );
 
@@ -64,6 +65,24 @@ class BuilderTest extends TestCase
         $props = $nestedMetadata->getProperties();
         $this->assertCount(1, $props, 'Number of properties should match');
         $this->assertProperty('nestedProperty', 'nested_property', false, false, $props[0]);
+    }
+
+    public function testPropertyWithDifferentSerializedName(): void
+    {
+        $c = new class {
+            /**
+             * @SerializedName("myProperty")
+             */
+            #[SerializedName('myProperty')]
+            public string $myProperty;
+        };
+
+        $classMetadata = $this->builder->build(\get_class($c));
+
+        $props = $classMetadata->getProperties();
+        $this->assertCount(1, $props, 'Number of properties should match');
+
+        $this->assertProperty('myProperty', 'myProperty', true, false, $props[0]);
     }
 
     private function assertProperty(string $name, string $serializedName, bool $public, bool $readOnly, PropertyMetadata $property): void

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -17,6 +17,7 @@ use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
 use Liip\MetadataParser\ModelParser\JMSParser;
 use Liip\MetadataParser\ModelParser\NamingStrategy\IdenticalPropertyNamingStrategy;
+use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyCollection;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
@@ -42,7 +43,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $this->assertSame(\get_class($c), $classMetadata->getClassName());
         $this->assertCount(0, $classMetadata->getPropertyCollections(), 'Number of properties should match');
@@ -54,7 +55,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('__invalid__');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testInvalidClassAnnotations(): void
@@ -69,7 +70,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('AccessType');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testUnsupportedClassAnnotations(): void
@@ -84,7 +85,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('unsupported attribute');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testClassXmlAnnotations(): void
@@ -97,7 +98,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -206,7 +207,7 @@ class JMSParserTest extends TestCase
     public function testPropertyType($c, string $propertyTypeClass, bool $nullable, string $type): void
     {
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -227,7 +228,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -254,7 +255,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('unexpected "__" (T_UNKNOWN)');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testInheritedProperty(): void
@@ -274,7 +275,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(3, $props, 'Number of properties should match');
@@ -305,7 +306,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -323,8 +324,8 @@ class JMSParserTest extends TestCase
 
         $classMetadata = new RawClassMetadata(\get_class($c));
 
-        $parser = new JMSParser(new AnnotationReader(), new IdenticalPropertyNamingStrategy());
-        $parser->parse($classMetadata);
+        $parser = new JMSParser(new AnnotationReader());
+        $parser->parse($classMetadata, new IdenticalPropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(2, $props, 'Number of properties should match');
@@ -350,7 +351,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -379,7 +380,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -400,7 +401,7 @@ class JMSParserTest extends TestCase
 
         $classMetadata = new RawClassMetadata(\get_class($c));
         $classMetadata->addPropertyVariation('property', new PropertyVariationMetadata('property', false, true));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -430,7 +431,7 @@ class JMSParserTest extends TestCase
         $classMetadata = new RawClassMetadata(\get_class($c));
         $classMetadata->addPropertyVariation('fake_links', new PropertyVariationMetadata('fakeLinks', false, true));
         $classMetadata->addPropertyVariation('links', new PropertyVariationMetadata('links', false, true));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -451,7 +452,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -473,7 +474,7 @@ class JMSParserTest extends TestCase
         $classMetadata->addPropertyVariation('property1', new PropertyVariationMetadata('property1', false, true));
         $classMetadata->addPropertyVariation('property2', new PropertyVariationMetadata('property2', false, true));
 
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -498,7 +499,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -521,7 +522,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('Exclude');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testGroups(): void
@@ -534,7 +535,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -565,7 +566,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(4, $props, 'Number of properties should match');
@@ -607,7 +608,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(4, $props, 'Number of properties should match');
@@ -648,7 +649,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('Type');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testPropertyXmlAnnotations(): void
@@ -671,7 +672,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -693,7 +694,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('unsupported attribute');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testOrder(): void
@@ -713,7 +714,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(5, $props, 'Number of properties should match');
@@ -738,7 +739,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('AccessorOrder');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testExclusionPolicy(): void
@@ -751,7 +752,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -771,7 +772,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('ExclusionPolicy');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testMethodWithoutDocBlock(): void
@@ -784,7 +785,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(0, $props, 'Number of properties should match');
@@ -803,7 +804,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -828,7 +829,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -853,7 +854,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -878,7 +879,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -906,7 +907,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('conflict');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testVirtualPropertyWithInvalidReturnDocBlock(): void
@@ -927,7 +928,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('resource');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testVirtualPropertyType(): void
@@ -945,7 +946,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -975,7 +976,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('conflict');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testVirtualPropertyTypeConflictingWithDocBlockType(): void
@@ -998,7 +999,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('conflict');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testVirtualPropertyTypeExtendingPrimitive(): void
@@ -1016,7 +1017,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -1042,7 +1043,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -1073,7 +1074,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -1107,7 +1108,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('unexpected "__" (T_UNKNOWN)');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testInvalidVirtualPropertyAnnotations(): void
@@ -1128,7 +1129,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('Type');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testPrivateVirtualProperty(): void
@@ -1147,7 +1148,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('public');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testVirtualPropertyExclude(): void
@@ -1165,7 +1166,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(0, $props, 'Number of properties should match');
@@ -1186,7 +1187,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -1212,7 +1213,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -1242,7 +1243,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -1278,7 +1279,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -1317,7 +1318,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -1342,7 +1343,7 @@ class JMSParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('unsupported attribute');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testPostDeserializedMethods(): void
@@ -1364,7 +1365,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $this->assertSame(['foo', 'bar'], $classMetadata->getPostDeserializeMethods());
     }
@@ -1379,7 +1380,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -1399,7 +1400,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(2, $props, 'Number of properties should match');
@@ -1437,7 +1438,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(3, $props, 'Number of properties should match');
@@ -1470,7 +1471,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -16,6 +16,7 @@ use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
 use Liip\MetadataParser\ModelParser\JMSParser;
+use Liip\MetadataParser\ModelParser\NamingStrategy\IdenticalPropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyCollection;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
@@ -32,7 +33,6 @@ class JMSParserTest extends TestCase
 
     protected function setUp(): void
     {
-        PropertyCollection::useIdenticalNamingStrategy(false);
         $this->parser = new JMSParser(new AnnotationReader());
     }
 
@@ -321,9 +321,10 @@ class JMSParserTest extends TestCase
             private $mySecondProperty;
         };
 
-        PropertyCollection::useIdenticalNamingStrategy();
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+
+        $parser = new JMSParser(new AnnotationReader(), new IdenticalPropertyNamingStrategy());
+        $parser->parse($classMetadata);
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(2, $props, 'Number of properties should match');
@@ -427,7 +428,7 @@ class JMSParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $classMetadata->addPropertyVariation('fakeLinks', new PropertyVariationMetadata('fakeLinks', false, true));
+        $classMetadata->addPropertyVariation('fake_links', new PropertyVariationMetadata('fakeLinks', false, true));
         $classMetadata->addPropertyVariation('links', new PropertyVariationMetadata('links', false, true));
         $this->parser->parse($classMetadata);
 

--- a/tests/ModelParser/NamingStrategy/SnakeCasePropertyNamingStrategyTest.php
+++ b/tests/ModelParser/NamingStrategy/SnakeCasePropertyNamingStrategyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\MetadataParser\ModelParser\NamingStrategy;
+
+use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @small
+ */
+class SnakeCasePropertyNamingStrategyTest extends TestCase
+{
+    private SnakeCasePropertyNamingStrategy $strategy;
+
+    protected function setUp(): void
+    {
+        $this->strategy = new SnakeCasePropertyNamingStrategy();
+    }
+
+    /**
+     * @dataProvider provideGetSerializedNameCases
+     */
+    public function testGetSerializedName(string $input, string $expected): void
+    {
+        $result = $this->strategy->getSerializedName($input);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public static function provideGetSerializedNameCases(): iterable
+    {
+        return [
+            ['camelCase', 'camel_case'],
+            ['foo', 'foo'],
+            ['word', 'word'],
+            ['wORD', 'w_o_r_d'],
+            ['', ''],
+            ['field1Name', 'field1_name'],
+            ['longerCamelCaseName', 'longer_camel_case_name'],
+        ];
+    }
+}

--- a/tests/ModelParser/PhpDocParserTest.php
+++ b/tests/ModelParser/PhpDocParserTest.php
@@ -11,6 +11,7 @@ use Liip\MetadataParser\Metadata\PropertyTypeClass;
 use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
+use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\PhpDocParser;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyCollection;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
@@ -40,7 +41,7 @@ class PhpDocParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $this->assertSame(\get_class($c), $classMetadata->getClassName());
         $this->assertCount(0, $classMetadata->getPropertyCollections(), 'Number of properties should match');
@@ -52,7 +53,7 @@ class PhpDocParserTest extends TestCase
 
         $this->expectException(ParseException::class);
         $this->expectExceptionMessage('__invalid__');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testInvalidType(): void
@@ -68,7 +69,7 @@ class PhpDocParserTest extends TestCase
 
         $this->expectException(InvalidTypeException::class);
         $this->expectExceptionMessage('resource');
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public static function providePropertyCases(): iterable
@@ -134,7 +135,7 @@ class PhpDocParserTest extends TestCase
     public function testProperty($c, string $propertyTypeClass, bool $nullable, string $type): void
     {
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -161,7 +162,7 @@ class PhpDocParserTest extends TestCase
 
         $classMetadata = new RawClassMetadata(\get_class($c));
         $classMetadata->addPropertyVariation('foo', new PropertyVariationMetadata('property1', false, true));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(2, $props, 'Number of properties should match');
@@ -190,7 +191,7 @@ class PhpDocParserTest extends TestCase
         $propertyMetadata = new PropertyVariationMetadata('property', false, true);
         $propertyMetadata->setType(new PropertyTypeIterable(new PropertyTypeUnknown(false), false, false));
         $classMetadata->addPropertyVariation('property', $propertyMetadata);
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');
@@ -216,7 +217,7 @@ class PhpDocParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(3, $props, 'Number of properties should match');
@@ -247,7 +248,7 @@ class PhpDocParserTest extends TestCase
         };
 
         $classMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($classMetadata);
+        $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $classMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of properties should match');

--- a/tests/ModelParser/RawMetadata/RawClassMetadataTest.php
+++ b/tests/ModelParser/RawMetadata/RawClassMetadataTest.php
@@ -22,7 +22,7 @@ class RawClassMetadataTest extends TestCase
         $this->assertCount(1, $collection->getVariations());
         $this->assertSame('test', $collection->getSerializedName());
 
-        $rawClassMetadata->renameProperty('test', 'new_name');
+        $rawClassMetadata->renameProperty('testProperty', 'new_name');
         $this->assertFalse($rawClassMetadata->hasPropertyCollection('test'));
         $this->assertTrue($rawClassMetadata->hasPropertyCollection('new_name'));
         $collection = $rawClassMetadata->getPropertyCollection('new_name');

--- a/tests/ModelParser/ReflectionParserTest.php
+++ b/tests/ModelParser/ReflectionParserTest.php
@@ -10,6 +10,7 @@ use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
+use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyCollection;
 use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
@@ -40,7 +41,7 @@ class ReflectionParserTest extends TestCase
         $rawClassMetadata = new RawClassMetadata('__invalid__');
 
         $this->expectException(ParseException::class);
-        $this->parser->parse($rawClassMetadata);
+        $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
     }
 
     public function testEmpty(): void
@@ -49,7 +50,7 @@ class ReflectionParserTest extends TestCase
         };
 
         $rawClassMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($rawClassMetadata);
+        $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
 
         $this->assertSame(\get_class($c), $rawClassMetadata->getClassName());
         $this->assertCount(0, $rawClassMetadata->getPropertyCollections(), 'Number of class metadata properties should match');
@@ -64,7 +65,7 @@ class ReflectionParserTest extends TestCase
         };
 
         $rawClassMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($rawClassMetadata);
+        $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $rawClassMetadata->getPropertyCollections();
         $this->assertCount(3, $props, 'Number of class metadata properties should match');
@@ -92,7 +93,7 @@ class ReflectionParserTest extends TestCase
         }
 
         $rawClassMetadata = new RawClassMetadata(TypeDeclarationModel::class);
-        $this->parser->parse($rawClassMetadata);
+        $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $rawClassMetadata->getPropertyCollections();
         $this->assertCount(3, $props, 'Number of class metadata properties should match');
@@ -120,7 +121,7 @@ class ReflectionParserTest extends TestCase
         }
 
         $rawClassMetadata = new RawClassMetadata(UnionTypeDeclarationModel::class);
-        $this->parser->parse($rawClassMetadata);
+        $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $rawClassMetadata->getPropertyCollections();
         $this->assertCount(2, $props, 'Number of class metadata properties should match');
@@ -143,7 +144,7 @@ class ReflectionParserTest extends TestCase
         }
 
         $rawClassMetadata = new RawClassMetadata(IntersectionTypeDeclarationModel::class);
-        $this->parser->parse($rawClassMetadata);
+        $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $rawClassMetadata->getPropertyCollections();
         $this->assertCount(1, $props, 'Number of class metadata properties should match');
@@ -164,7 +165,7 @@ class ReflectionParserTest extends TestCase
 
         $rawClassMetadata = new RawClassMetadata(\get_class($c));
         $rawClassMetadata->addPropertyVariation('foo', new PropertyVariationMetadata('property1', false, true));
-        $this->parser->parse($rawClassMetadata);
+        $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $rawClassMetadata->getPropertyCollections();
         $this->assertCount(2, $props, 'Number of class metadata properties should match');
@@ -188,7 +189,7 @@ class ReflectionParserTest extends TestCase
         };
 
         $rawClassMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($rawClassMetadata);
+        $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
 
         $props = $rawClassMetadata->getPropertyCollections();
         $this->assertCount(3, $props, 'Number of class metadata properties should match');
@@ -219,7 +220,7 @@ class ReflectionParserTest extends TestCase
         };
 
         $rawClassMetadata = new RawClassMetadata(\get_class($c));
-        $this->parser->parse($rawClassMetadata);
+        $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
 
         $parameters = $rawClassMetadata->getConstructorParameters();
         $this->assertCount(3, $parameters, 'Number of constructor parameters should match');

--- a/tests/ModelParser/VisibilityAwarePropertyAccessGuesserTest.php
+++ b/tests/ModelParser/VisibilityAwarePropertyAccessGuesserTest.php
@@ -6,6 +6,7 @@ namespace Tests\Liip\MetadataParser\ModelParser;
 
 use Generator;
 use Liip\MetadataParser\ModelParser\ModelParserInterface;
+use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
 use Liip\MetadataParser\ModelParser\ReflectionParser;
 use Liip\MetadataParser\ModelParser\VisibilityAwarePropertyAccessGuesser;
@@ -49,7 +50,7 @@ class VisibilityAwarePropertyAccessGuesserTest extends TestCase
         $classMetadata = new RawClassMetadata($class);
 
         foreach ($parsers as $parser) {
-            $parser->parse($classMetadata);
+            $parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
         }
 
         return $classMetadata;


### PR DESCRIPTION
While working on discriminator support, I stumbled upon a bug where it was impossible to force a `camelCase` name for a property.

So using a class like this:

```php
class MyClass {
    #[SerializedName('myProperty')]
    public string $myProperty;
}
```

would result in the following error

```
LogicException : You can not rename my_property into myProperty as it is the same property. Did you miss to handle camelCase properties with PropertyCollection::serializedName?

```

With the changes I did in this PR, it is now possible to pass different property naming strategies to the different parsers.
Besides fixing the bug at hand, this also provides more freedom when it comes to property collection handling, as you don't have to be aware that the collection itself creates the serialized name, but instead it is up to the caller to decide what serialized name should be used.