### PR TITLE
Add enum support 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
         include:
-          - php-version: '8.0'
+          - php-version: '8.1'
             composer-flags: '--prefer-stable --prefer-lowest'
     steps:
       - name: Check out code into the workspace

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -34,6 +34,7 @@ $config
             'php_unit_mock' => true,
             'php_unit_namespaced' => true,
             'php_unit_no_expectation_annotation' => true,
+            'php_unit_data_provider_method_order' => false,
             'phpdoc_to_return_type' => true,
             'static_lambda' => true,
             'ternary_to_null_coalescing' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 # 2.1.0 (unreleased)
 
 * Add support for enums
+* Drop support for PHP 8.0
 
 # 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Version 2.x
 
+# 2.1.0 (unreleased)
+
+* Add support for enums
+
 # 2.0.0
 
 * Removed `PropertyTypeArray`, which is superseded by `PropertyTypeIterable`.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "issues": "https://github.com/liip/metadata-parser/issues"
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "doctrine/annotations": "^2.0.2",
         "psr/log": "^1|^2|^3"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "doctrine/collections": "^1.6",
-        "friendsofphp/php-cs-fixer": "v3.68.1",
+        "friendsofphp/php-cs-fixer": "^v3.94.2",
         "jms/serializer": "^2.3 || ^3",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "doctrine/collections": "^1.6",
         "friendsofphp/php-cs-fixer": "^v3.94.2",
         "jms/serializer": "^2.3 || ^3",
-        "phpstan/phpstan": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan": "^2.1.44",
+        "phpstan/phpstan-phpunit": "^2.0.16",
         "phpunit/phpunit": "^8.5.15 || ^9.5"
     },
     "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,5 +4,3 @@ parameters:
         - PHP_VERSION_ID
     paths:
         - src/
-    excludePaths:
-        - src/ModelParser/JMSParserLegacy.php

--- a/phpstan.tests.neon
+++ b/phpstan.tests.neon
@@ -3,6 +3,5 @@ parameters:
     paths:
         - tests/
     excludePaths:
-        - tests/ModelParser/JMSParserTestLegacy.php
         # looks like phpstan php parser has not implemented union types yet
         - tests/ModelParser/Fixtures/IntersectionTypeDeclarationModel.php

--- a/phpstan.tests.neon
+++ b/phpstan.tests.neon
@@ -3,5 +3,8 @@ parameters:
     paths:
         - tests/
     excludePaths:
+        # Excluded until the minimum version required from jms/serializer is set to >= 3.31.0
+        - tests/ModelParser/Model/ClassUsingUnionDiscriminator.php
+        - tests/ModelParser/Model/ClassUsingUnionTyping.php
         # looks like phpstan php parser has not implemented union types yet
         - tests/ModelParser/Fixtures/IntersectionTypeDeclarationModel.php

--- a/src/Metadata/ClassDiscriminatorMetadata.php
+++ b/src/Metadata/ClassDiscriminatorMetadata.php
@@ -33,11 +33,7 @@ class ClassDiscriminatorMetadata
     {
         $this->classMetadataList = [];
         foreach ($classMetadataList as $classMetadata) {
-            if (!$classMetadata instanceof ClassMetadata) {
-                throw new \InvalidArgumentException(\sprintf('Expected instance of %s', ClassMetadata::class));
-            }
-
-            $this->classMetadataList[$classMetadata->getClassName()] = $classMetadata;
+            $this->addClassMetadata($classMetadata);
         }
     }
 
@@ -49,5 +45,10 @@ class ClassDiscriminatorMetadata
     public function getMetadataForClass(string $className): ?ClassMetadata
     {
         return $this->classMetadataList[$className] ?? null;
+    }
+
+    private function addClassMetadata(ClassMetadata $classMetadata): void
+    {
+        $this->classMetadataList[$classMetadata->getClassName()] = $classMetadata;
     }
 }

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -48,6 +48,7 @@ final class ClassMetadata implements \JsonSerializable
     public function __construct(string $className, array $properties, array $constructorParameters = [], array $postDeserializeMethods = [], ?ClassDiscriminatorMetadata $discriminatorMetadata = null)
     {
         \assert(array_reduce($constructorParameters, static function (bool $carry, $parameter): bool {
+            /* @phpstan-ignore instanceof.alwaysTrue */
             return $carry && $parameter instanceof ParameterMetadata;
         }, true));
 

--- a/src/Metadata/DateTimeOptions.php
+++ b/src/Metadata/DateTimeOptions.php
@@ -22,14 +22,14 @@ final class DateTimeOptions implements \JsonSerializable
     /**
      * Use if different formats should be used for parsing dates than for generating dates.
      *
-     * @var string[]|null
+     * @var list<string>|null
      */
     private $deserializeFormats;
 
     /**
      * @note Passing a string for $deserializeFormats is deprecated, please pass an array instead
      *
-     * @param string[]|null $deserializeFormats
+     * @param list<string>|null $deserializeFormats
      */
     public function __construct(?string $format, ?string $zone, ?array $deserializeFormats)
     {
@@ -48,6 +48,9 @@ final class DateTimeOptions implements \JsonSerializable
         return $this->zone;
     }
 
+    /**
+     * @return list<string>|null
+     */
     public function getDeserializeFormats(): ?array
     {
         return $this->deserializeFormats;

--- a/src/Metadata/PropertyTypeDateTime.php
+++ b/src/Metadata/PropertyTypeDateTime.php
@@ -58,6 +58,9 @@ final class PropertyTypeDateTime extends AbstractPropertyType
         return null;
     }
 
+    /**
+     * @return list<string>|null
+     */
     public function getDeserializeFormats(): ?array
     {
         if ($this->dateTimeOptions) {

--- a/src/Metadata/PropertyTypeEnum.php
+++ b/src/Metadata/PropertyTypeEnum.php
@@ -11,12 +11,9 @@ final class PropertyTypeEnum extends AbstractPropertyType
     private string $className;
     private ?string $backingType;
 
-    /**
-     * @var "name"|"value"|null
-     */
-    private ?string $serializationMode;
+    private ?SerializationMode $serializationMode;
 
-    public function __construct(string $className, bool $nullable, ?string $serializationMode = null)
+    public function __construct(string $className, bool $nullable, ?SerializationMode $serializationMode = null)
     {
         parent::__construct($nullable);
         if (!enum_exists($className)) {
@@ -54,14 +51,14 @@ final class PropertyTypeEnum extends AbstractPropertyType
         return null !== $this->backingType;
     }
 
-    public function getSerializationMode(): ?string
+    public function getSerializationMode(): ?SerializationMode
     {
         return $this->serializationMode;
     }
 
     public function shouldSerializeAsValue(): bool
     {
-        return $this->isBackedEnum() && 'name' !== $this->serializationMode;
+        return $this->isBackedEnum() && SerializationMode::Name !== $this->serializationMode;
     }
 
     public function merge(PropertyType $other): PropertyType
@@ -81,7 +78,7 @@ final class PropertyTypeEnum extends AbstractPropertyType
         }
 
         if (null !== $this->serializationMode && null !== $other->getSerializationMode() && $this->serializationMode !== $other->getSerializationMode()) {
-            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with conflicting serialization modes "%s" and "%s"', self::class, $this->serializationMode, $other->getSerializationMode()));
+            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with conflicting serialization modes "%s" and "%s"', self::class, $this->serializationMode->value, $other->getSerializationMode()->value));
         }
 
         $serializationMode = $this->serializationMode ?? $other->getSerializationMode();

--- a/src/Metadata/PropertyTypeEnum.php
+++ b/src/Metadata/PropertyTypeEnum.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liip\MetadataParser\Metadata;
+
+use Liip\MetadataParser\Exception\InvalidTypeException;
+
+final class PropertyTypeEnum extends AbstractPropertyType
+{
+    private string $className;
+    private ?string $backingType;
+
+    /**
+     * @var "name"|"value"|null
+     */
+    private ?string $serializationMode;
+
+    public function __construct(string $className, bool $nullable, ?string $serializationMode = null)
+    {
+        parent::__construct($nullable);
+        if (\PHP_VERSION_ID < 80100 || !enum_exists($className)) {
+            throw new InvalidTypeException(\sprintf('Given type "%s" is not a PHP 8.1 enum', $className));
+        }
+
+        $this->className = $className;
+        $this->backingType = null;
+        $this->serializationMode = $serializationMode;
+
+        if (is_a($className, \BackedEnum::class, true)) {
+            $reflEnum = new \ReflectionEnum($className);
+            $this->backingType = $reflEnum->getBackingType()?->getName();
+        }
+    }
+
+    public function __toString(): string
+    {
+        return $this->className.parent::__toString();
+    }
+
+    public function getClassName(): string
+    {
+        return $this->className;
+    }
+
+    public function getBackingType(): ?string
+    {
+        return $this->backingType;
+    }
+
+    public function isBackedEnum(): bool
+    {
+        return null !== $this->backingType;
+    }
+
+    public function getSerializationMode(): ?string
+    {
+        return $this->serializationMode;
+    }
+
+    public function shouldSerializeAsValue(): bool
+    {
+        return $this->isBackedEnum() && 'name' !== $this->serializationMode;
+    }
+
+    public function merge(PropertyType $other): PropertyType
+    {
+        $nullable = $this->isNullable() && $other->isNullable();
+
+        if ($other instanceof PropertyTypeUnknown) {
+            return new self($this->className, $nullable, $this->serializationMode);
+        }
+
+        if (!$other instanceof self) {
+            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with %s, they must be the same or unknown', self::class, \get_class($other)));
+        }
+
+        if ($this->getClassName() !== $other->getClassName()) {
+            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with %s, they must be equal', self::class, \get_class($other)));
+        }
+
+        if (null !== $this->serializationMode && null !== $other->getSerializationMode() && $this->serializationMode !== $other->getSerializationMode()) {
+            throw new \UnexpectedValueException(\sprintf('Can\'t merge type %s with conflicting serialization modes "%s" and "%s"', self::class, $this->serializationMode, $other->getSerializationMode()));
+        }
+
+        $serializationMode = $this->serializationMode ?? $other->getSerializationMode();
+
+        return new self($this->className, $nullable, $serializationMode);
+    }
+}

--- a/src/Metadata/PropertyTypeEnum.php
+++ b/src/Metadata/PropertyTypeEnum.php
@@ -19,7 +19,7 @@ final class PropertyTypeEnum extends AbstractPropertyType
     public function __construct(string $className, bool $nullable, ?string $serializationMode = null)
     {
         parent::__construct($nullable);
-        if (\PHP_VERSION_ID < 80100 || !enum_exists($className)) {
+        if (!enum_exists($className)) {
             throw new InvalidTypeException(\sprintf('Given type "%s" is not a PHP 8.1 enum', $className));
         }
 

--- a/src/Metadata/PropertyTypeEnum.php
+++ b/src/Metadata/PropertyTypeEnum.php
@@ -27,9 +27,10 @@ final class PropertyTypeEnum extends AbstractPropertyType
         $this->backingType = null;
         $this->serializationMode = $serializationMode;
 
-        if (is_a($className, \BackedEnum::class, true)) {
-            $reflEnum = new \ReflectionEnum($className);
-            $this->backingType = $reflEnum->getBackingType()?->getName();
+        $reflEnum = new \ReflectionEnum($className);
+        $backingType = $reflEnum->getBackingType();
+        if ($backingType instanceof \ReflectionNamedType) {
+            $this->backingType = $backingType->getName();
         }
     }
 

--- a/src/Metadata/PropertyTypeUnion.php
+++ b/src/Metadata/PropertyTypeUnion.php
@@ -139,8 +139,8 @@ final class PropertyTypeUnion extends AbstractPropertyType
                 $secondTypeName = $second->getTypeName();
             }
 
-            $firstOrder = $order[$firstTypeName] ?? self::DEFAULT_ORDER;
-            $secondOrder = $order[$secondTypeName] ?? self::DEFAULT_ORDER;
+            $firstOrder = $order[$firstTypeName ?? ''] ?? self::DEFAULT_ORDER;
+            $secondOrder = $order[$secondTypeName ?? ''] ?? self::DEFAULT_ORDER;
 
             return $firstOrder <=> $secondOrder;
         });

--- a/src/Metadata/SerializationMode.php
+++ b/src/Metadata/SerializationMode.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liip\MetadataParser\Metadata;
+
+enum SerializationMode: string
+{
+    case Value = 'value';
+    case Name = 'name';
+}

--- a/src/ModelParser/JMSParser.php
+++ b/src/ModelParser/JMSParser.php
@@ -274,7 +274,7 @@ final class JMSParser implements ModelParserInterface
                 case $attribute instanceof MaxDepth:
                     $property->setMaxDepth($attribute->depth);
                     break;
-                case $attribute instanceof UnionDiscriminator:
+                case class_exists(UnionDiscriminator::class) && $attribute instanceof UnionDiscriminator:
                     $types = [];
                     $isNullable = $this->isNullable($reflection);
                     if ($isNullable) {

--- a/src/ModelParser/JMSParser.php
+++ b/src/ModelParser/JMSParser.php
@@ -228,7 +228,7 @@ final class JMSParser implements ModelParserInterface
                         throw ParseException::propertyTypeNameNull((string) $classMetadata, (string) $property);
                     }
                     try {
-                        $type = $this->jmsTypeParser->parse($attribute->name);
+                        $type = $this->jmsTypeParser->parse($attribute->name, $reflection);
                     } catch (InvalidTypeException $e) {
                         throw ParseException::propertyTypeError((string) $classMetadata, (string) $property, $e);
                     }
@@ -282,7 +282,7 @@ final class JMSParser implements ModelParserInterface
                     }
 
                     foreach ($attribute->map as $value) {
-                        $types[] = $this->jmsTypeParser->parse($value, true);
+                        $types[] = $this->jmsTypeParser->parse($value, $reflection, true);
                     }
 
                     $type = new PropertyTypeUnion($types, $isNullable);

--- a/src/TypeParser/JMSTypeParser.php
+++ b/src/TypeParser/JMSTypeParser.php
@@ -11,6 +11,7 @@ use Liip\MetadataParser\Metadata\DateTimeOptions;
 use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
 use Liip\MetadataParser\Metadata\PropertyTypeDateTime;
+use Liip\MetadataParser\Metadata\PropertyTypeEnum;
 use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
@@ -18,6 +19,7 @@ use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
 final class JMSTypeParser
 {
     private const TYPE_ARRAY = 'array';
+    private const TYPE_ENUM = 'enum';
     private const TYPE_ARRAY_COLLECTION = 'ArrayCollection';
     private const TYPE_GENERATOR = 'Generator';
     private const TYPE_ARRAY_ITERATOR = 'ArrayIterator';
@@ -68,6 +70,10 @@ final class JMSTypeParser
                 return PropertyTypeDateTime::fromDateTimeClass($typeInfo['name'], $nullable);
             }
 
+            if (self::TYPE_ENUM === $typeInfo['name']) {
+                throw new InvalidTypeException('JMS enum type requires a class name parameter, e.g. "enum<MyEnum>"');
+            }
+
             return new PropertyTypeClass($typeInfo['name'], $nullable);
         }
 
@@ -104,6 +110,15 @@ final class JMSTypeParser
             );
         }
 
+        if (self::TYPE_ENUM === $typeInfo['name']) {
+            $enumType = $typeInfo['params'][0];
+            $enumType = $enumType['name'] ?? $enumType;
+
+            $serializationMode = $this->getEnumSerializationMode($enumType, $typeInfo['params']);
+
+            return new PropertyTypeEnum($enumType, $nullable, $serializationMode);
+        }
+
         throw new InvalidTypeException(\sprintf('Unknown JMS property found (%s)', var_export($typeInfo, true)));
     }
 
@@ -120,5 +135,19 @@ final class JMSTypeParser
             default:
                 return is_a($name, \Traversable::class, true) ? $name : null;
         }
+    }
+
+    private function getEnumSerializationMode(string $enumType, array $typeParams): ?string
+    {
+        $mode = $typeParams[1] ?? null;
+        if (null === $mode) {
+            return null;
+        }
+
+        if ('value' === $mode && !is_a($enumType, \BackedEnum::class, true)) {
+            throw new InvalidTypeException(\sprintf('The type "%s" is not a backed enum, thus you cannot use "value" as serialization mode for its value.', $enumType));
+        }
+
+        return $mode;
     }
 }

--- a/src/TypeParser/JMSTypeParser.php
+++ b/src/TypeParser/JMSTypeParser.php
@@ -15,6 +15,7 @@ use Liip\MetadataParser\Metadata\PropertyTypeEnum;
 use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
+use Liip\MetadataParser\Metadata\SerializationMode;
 
 final class JMSTypeParser
 {
@@ -129,18 +130,19 @@ final class JMSTypeParser
         }
     }
 
-    private function getEnumSerializationMode(string $enumType, array $typeParams): ?string
+    private function getEnumSerializationMode(string $enumType, array $typeParams): ?SerializationMode
     {
         $mode = $typeParams[1] ?? null;
         if (null === $mode) {
             return null;
         }
 
-        if ('value' === $mode && !is_a($enumType, \BackedEnum::class, true)) {
+        $serializationMode = SerializationMode::tryFrom($mode);
+        if (SerializationMode::Value === $serializationMode && !is_a($enumType, \BackedEnum::class, true)) {
             throw new InvalidTypeException(\sprintf('The type "%s" is not a backed enum, thus you cannot use "value" as serialization mode for its value.', $enumType));
         }
 
-        return $mode;
+        return $serializationMode;
     }
 
     private function getEnumType(array $typeInfo, \ReflectionProperty|\ReflectionMethod|null $reflection): string

--- a/src/TypeParser/JMSTypeParser.php
+++ b/src/TypeParser/JMSTypeParser.php
@@ -26,26 +26,23 @@ final class JMSTypeParser
     private const TYPE_ITERATOR = 'Iterator';
     private const TYPE_DATETIME_INTERFACE = 'DateTimeInterface';
 
-    /**
-     * @var Parser
-     */
-    private $jmsTypeParser;
+    private Parser $jmsTypeParser;
 
     public function __construct()
     {
         $this->jmsTypeParser = new Parser();
     }
 
-    public function parse(string $rawType, bool $isSubType = false): PropertyType
+    public function parse(string $rawType, \ReflectionProperty|\ReflectionMethod|null $reflection = null, bool $isSubType = false): PropertyType
     {
         if ('' === $rawType) {
             return new PropertyTypeUnknown(true);
         }
 
-        return $this->parseType($this->jmsTypeParser->parse($rawType), $isSubType);
+        return $this->parseType($this->jmsTypeParser->parse($rawType), $reflection, $isSubType);
     }
 
-    private function parseType(array $typeInfo, bool $isSubType = false): PropertyType
+    private function parseType(array $typeInfo, \ReflectionProperty|\ReflectionMethod|null $reflection, bool $isSubType = false): PropertyType
     {
         $typeInfo = array_merge(
             [
@@ -58,7 +55,7 @@ final class JMSTypeParser
         // JMS types are nullable except if it's a sub type (part of array)
         $nullable = !$isSubType;
 
-        if (0 === \count($typeInfo['params'])) {
+        if (0 === \count($typeInfo['params']) && self::TYPE_ENUM !== $typeInfo['name']) {
             if (self::TYPE_ARRAY === $typeInfo['name']) {
                 return new PropertyTypeIterable(new PropertyTypeUnknown(false), false, $nullable);
             }
@@ -70,20 +67,16 @@ final class JMSTypeParser
                 return PropertyTypeDateTime::fromDateTimeClass($typeInfo['name'], $nullable);
             }
 
-            if (self::TYPE_ENUM === $typeInfo['name']) {
-                throw new InvalidTypeException('JMS enum type requires a class name parameter, e.g. "enum<MyEnum>"');
-            }
-
             return new PropertyTypeClass($typeInfo['name'], $nullable);
         }
 
         $traversableClass = $this->getTraversableClass($typeInfo['name']);
         if (self::TYPE_ARRAY === $typeInfo['name'] || $traversableClass) {
             if (1 === \count($typeInfo['params'])) {
-                return new PropertyTypeIterable($this->parseType($typeInfo['params'][0], true), false, $nullable, $traversableClass);
+                return new PropertyTypeIterable($this->parseType($typeInfo['params'][0], $reflection, true), false, $nullable, $traversableClass);
             }
             if (2 === \count($typeInfo['params'])) {
-                return new PropertyTypeIterable($this->parseType($typeInfo['params'][1], true), true, $nullable, $traversableClass);
+                return new PropertyTypeIterable($this->parseType($typeInfo['params'][1], $reflection, true), true, $nullable, $traversableClass);
             }
 
             throw new InvalidTypeException(\sprintf('JMS property type array can\'t have more than 2 parameters (%s)', var_export($typeInfo, true)));
@@ -111,8 +104,7 @@ final class JMSTypeParser
         }
 
         if (self::TYPE_ENUM === $typeInfo['name']) {
-            $enumType = $typeInfo['params'][0];
-            $enumType = $enumType['name'] ?? $enumType;
+            $enumType = $this->getEnumType($typeInfo, $reflection);
 
             $serializationMode = $this->getEnumSerializationMode($enumType, $typeInfo['params']);
 
@@ -149,5 +141,27 @@ final class JMSTypeParser
         }
 
         return $mode;
+    }
+
+    private function getEnumType(array $typeInfo, \ReflectionProperty|\ReflectionMethod|null $reflection): string
+    {
+        $enumType = $typeInfo['params'][0] ?? null;
+        $enumType = $enumType['name'] ?? $enumType;
+        if (null !== $enumType) {
+            return $enumType;
+        }
+
+        $class = null === $reflection ? null : $reflection::class;
+        $type = match ($class) {
+            \ReflectionMethod::class => $reflection->getReturnType(),
+            \ReflectionProperty::class => $reflection->getType(),
+            default => null,
+        };
+
+        if (!$type instanceof \ReflectionNamedType) {
+            throw new InvalidTypeException('Can not determine enum type from reflection, please define one by using "enum<MyEnum>"');
+        }
+
+        return $type->getName();
     }
 }

--- a/src/TypeParser/PhpTypeParser.php
+++ b/src/TypeParser/PhpTypeParser.php
@@ -9,6 +9,7 @@ use Liip\MetadataParser\Exception\InvalidTypeException;
 use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
 use Liip\MetadataParser\Metadata\PropertyTypeDateTime;
+use Liip\MetadataParser\Metadata\PropertyTypeEnum;
 use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
@@ -115,6 +116,10 @@ final class PhpTypeParser
 
         if (PropertyTypeDateTime::isTypeDateTime($resolvedClass)) {
             return PropertyTypeDateTime::fromDateTimeClass($resolvedClass, $nullable);
+        }
+
+        if (\PHP_VERSION_ID >= 80100 && enum_exists($resolvedClass)) {
+            return new PropertyTypeEnum($resolvedClass, $nullable);
         }
 
         return new PropertyTypeClass($resolvedClass, $nullable);

--- a/src/TypeParser/PhpTypeParser.php
+++ b/src/TypeParser/PhpTypeParser.php
@@ -118,7 +118,7 @@ final class PhpTypeParser
             return PropertyTypeDateTime::fromDateTimeClass($resolvedClass, $nullable);
         }
 
-        if (\PHP_VERSION_ID >= 80100 && enum_exists($resolvedClass)) {
+        if (enum_exists($resolvedClass)) {
             return new PropertyTypeEnum($resolvedClass, $nullable);
         }
 

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -111,10 +111,6 @@ class BuilderTest extends TestCase
 
     public function testUnionDiscriminatorClassMetadataList(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Intersection property types are only supported in PHP 8.1 or newer');
-        }
-
         $classMetadata = $this->builder->build(ClassUsingUnionDiscriminator::class);
 
         $props = $classMetadata->getProperties();
@@ -126,10 +122,6 @@ class BuilderTest extends TestCase
 
     public function testUnionTypingClassMetadataList(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Intersection property types are only supported in PHP 8.1 or newer');
-        }
-
         $classMetadata = $this->builder->build(ClassUsingUnionTyping::class);
 
         $props = $classMetadata->getProperties();

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -11,6 +11,7 @@ use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\Metadata\PropertyMetadata;
 use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
+use Liip\MetadataParser\Metadata\PropertyTypeEnum;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnion;
 use Liip\MetadataParser\ModelParser\JMSParser;
@@ -23,6 +24,7 @@ use Psr\Log\LoggerInterface;
 use Tests\Liip\MetadataParser\ModelParser\Model\Car;
 use Tests\Liip\MetadataParser\ModelParser\Model\ClassUsingUnionDiscriminator;
 use Tests\Liip\MetadataParser\ModelParser\Model\ClassUsingUnionTyping;
+use Tests\Liip\MetadataParser\ModelParser\Model\ClassWithEnums;
 use Tests\Liip\MetadataParser\ModelParser\Model\Moped;
 use Tests\Liip\MetadataParser\ModelParser\Model\Nested;
 
@@ -138,6 +140,26 @@ class BuilderTest extends TestCase
 
         $this->assertProperty('property', 'property', true, false, $props[0]);
         $this->assertPropertyType($props[0]->getType(), PropertyTypeUnion::class, 'Tests\Liip\MetadataParser\ModelParser\Model\DiscriminatorComment|Tests\Liip\MetadataParser\ModelParser\Model\DiscriminatorAuthor', false);
+    }
+
+    public function testEnumClassMetadataList(): void
+    {
+        $classMetadata = $this->builder->build(ClassWithEnums::class);
+
+        $props = $classMetadata->getProperties();
+        $this->assertCount(4, $props, 'Number of properties should match');
+
+        $this->assertProperty('suit', 'suit', true, false, $props[0]);
+        $this->assertPropertyType($props[0]->getType(), PropertyTypeEnum::class, 'Tests\Liip\MetadataParser\ModelParser\Fixtures\SuitEnum', false);
+
+        $this->assertProperty('suitWithName', 'suit_with_name', true, false, $props[1]);
+        $this->assertPropertyType($props[1]->getType(), PropertyTypeEnum::class, 'Tests\Liip\MetadataParser\ModelParser\Fixtures\SuitEnum', false);
+
+        $this->assertProperty('suitWithoutType', 'suit_without_type', true, false, $props[2]);
+        $this->assertPropertyType($props[2]->getType(), PropertyTypeEnum::class, 'Tests\Liip\MetadataParser\ModelParser\Fixtures\SuitEnum', false);
+
+        $this->assertProperty('direction', 'direction', true, false, $props[3]);
+        $this->assertPropertyType($props[3]->getType(), PropertyTypeEnum::class, 'Tests\Liip\MetadataParser\ModelParser\Fixtures\DirectionEnum', false);
     }
 
     private function assertProperty(string $name, string $serializedName, bool $public, bool $readOnly, PropertyMetadata $property): void

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -6,6 +6,7 @@ namespace Tests\Liip\MetadataParser;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\Serializer\Annotation\SerializedName;
+use JMS\Serializer\Annotation\UnionDiscriminator;
 use Liip\MetadataParser\Builder;
 use Liip\MetadataParser\Metadata\PropertyMetadata;
 use Liip\MetadataParser\Metadata\PropertyType;
@@ -111,6 +112,10 @@ class BuilderTest extends TestCase
 
     public function testUnionDiscriminatorClassMetadataList(): void
     {
+        if (!class_exists(UnionDiscriminator::class)) {
+            $this->markTestSkipped('UnionDiscriminator attribute from JMS missing');
+        }
+
         $classMetadata = $this->builder->build(ClassUsingUnionDiscriminator::class);
 
         $props = $classMetadata->getProperties();
@@ -122,6 +127,10 @@ class BuilderTest extends TestCase
 
     public function testUnionTypingClassMetadataList(): void
     {
+        if (!class_exists(UnionDiscriminator::class)) {
+            $this->markTestSkipped('UnionDiscriminator attribute from JMS missing');
+        }
+
         $classMetadata = $this->builder->build(ClassUsingUnionTyping::class);
 
         $props = $classMetadata->getProperties();

--- a/tests/Metadata/PropertyTypeEnumTest.php
+++ b/tests/Metadata/PropertyTypeEnumTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\MetadataParser\Metadata;
+
+use Liip\MetadataParser\Exception\InvalidTypeException;
+use Liip\MetadataParser\Metadata\PropertyTypeEnum;
+use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
+use PHPUnit\Framework\TestCase;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\DirectionEnum;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\SuitEnum;
+
+/**
+ * @small
+ */
+class PropertyTypeEnumTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
+        }
+    }
+
+    public function testToStringBackedEnum(): void
+    {
+        $type = new PropertyTypeEnum(SuitEnum::class, false);
+        $this->assertSame(SuitEnum::class, (string) $type);
+    }
+
+    public function testToStringNullable(): void
+    {
+        $type = new PropertyTypeEnum(SuitEnum::class, true);
+        $this->assertSame(SuitEnum::class.'|null', (string) $type);
+    }
+
+    public function testSerializationModeForBackedEnum(): void
+    {
+        $type = new PropertyTypeEnum(SuitEnum::class, false);
+        $this->assertTrue($type->shouldSerializeAsValue());
+    }
+
+    public function testGetBackingTypeForBackedEnum(): void
+    {
+        $type = new PropertyTypeEnum(SuitEnum::class, false);
+        $this->assertSame('string', $type->getBackingType());
+    }
+
+    public function testGetBackingTypeForUnitEnum(): void
+    {
+        $type = new PropertyTypeEnum(DirectionEnum::class, false);
+        $this->assertNull($type->getBackingType());
+        $this->assertNull($type->getSerializationMode());
+    }
+
+    public function testIsBackedEnum(): void
+    {
+        $backedType = new PropertyTypeEnum(SuitEnum::class, false);
+        $this->assertTrue($backedType->isBackedEnum());
+
+        $unitType = new PropertyTypeEnum(DirectionEnum::class, false);
+        $this->assertFalse($unitType->isBackedEnum());
+    }
+
+    public function testMergeWithSameEnum(): void
+    {
+        $typeA = new PropertyTypeEnum(SuitEnum::class, true);
+        $typeB = new PropertyTypeEnum(SuitEnum::class, false);
+
+        $result = $typeA->merge($typeB);
+
+        $this->assertInstanceOf(PropertyTypeEnum::class, $result);
+        $this->assertSame(SuitEnum::class, $result->getClassName());
+        $this->assertFalse($result->isNullable());
+    }
+
+    public function testMergeWithDifferentEnumThrows(): void
+    {
+        $typeA = new PropertyTypeEnum(SuitEnum::class, false);
+        $typeB = new PropertyTypeEnum(DirectionEnum::class, false);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $typeA->merge($typeB);
+    }
+
+    public function testMergeWithUnknownSucceeds(): void
+    {
+        $type = new PropertyTypeEnum(SuitEnum::class, true);
+        $unknown = new PropertyTypeUnknown(false);
+
+        $result = $type->merge($unknown);
+
+        $this->assertInstanceOf(PropertyTypeEnum::class, $result);
+        $this->assertSame(SuitEnum::class, $result->getClassName());
+        $this->assertFalse($result->isNullable());
+    }
+
+    public function testConstructorThrowsForNonEnum(): void
+    {
+        $this->expectException(InvalidTypeException::class);
+        new PropertyTypeEnum(\stdClass::class, false);
+    }
+}

--- a/tests/Metadata/PropertyTypeEnumTest.php
+++ b/tests/Metadata/PropertyTypeEnumTest.php
@@ -16,13 +16,6 @@ use Tests\Liip\MetadataParser\ModelParser\Fixtures\SuitEnum;
  */
 class PropertyTypeEnumTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
-        }
-    }
-
     public function testToStringBackedEnum(): void
     {
         $type = new PropertyTypeEnum(SuitEnum::class, false);

--- a/tests/Metadata/PropertyTypeTest.php
+++ b/tests/Metadata/PropertyTypeTest.php
@@ -49,14 +49,12 @@ class PropertyTypeTest extends TestCase
             false,
         ];
 
-        if (\PHP_VERSION_ID >= 80100) {
-            yield [
-                new PropertyTypeEnum(SuitEnum::class, true),
-                new PropertyTypeUnknown(false),
-                SuitEnum::class,
-                false,
-            ];
-        }
+        yield [
+            new PropertyTypeEnum(SuitEnum::class, true),
+            new PropertyTypeUnknown(false),
+            SuitEnum::class,
+            false,
+        ];
 
         yield [
             new PropertyTypeIterable(new PropertyTypePrimitive('bool', false), false, true),
@@ -166,22 +164,17 @@ class PropertyTypeTest extends TestCase
      */
     private function getDifferentTypes(): array
     {
-        $types = [
+        return [
             new PropertyTypeUnknown(true),
             new PropertyTypePrimitive('string', true),
             new PropertyTypePrimitive('int', true),
             new PropertyTypeDateTime(false, true),
             new PropertyTypeDateTime(true, true),
+            new PropertyTypeEnum(SuitEnum::class, true),
             new PropertyTypeClass(\stdClass::class, true),
             new PropertyTypeIterable(new PropertyTypePrimitive('bool', false), false, true),
             new PropertyTypeIterable(new PropertyTypePrimitive('int', false), false, true),
             new PropertyTypeIterable(new PropertyTypePrimitive('string', false), true, true),
         ];
-
-        if (\PHP_VERSION_ID >= 80100) {
-            $types[] = new PropertyTypeEnum(SuitEnum::class, true);
-        }
-
-        return $types;
     }
 }

--- a/tests/Metadata/PropertyTypeTest.php
+++ b/tests/Metadata/PropertyTypeTest.php
@@ -7,10 +7,12 @@ namespace Tests\Liip\MetadataParser\Metadata;
 use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
 use Liip\MetadataParser\Metadata\PropertyTypeDateTime;
+use Liip\MetadataParser\Metadata\PropertyTypeEnum;
 use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
 use PHPUnit\Framework\TestCase;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\SuitEnum;
 
 /**
  * @small
@@ -46,6 +48,15 @@ class PropertyTypeTest extends TestCase
             'stdClass',
             false,
         ];
+
+        if (\PHP_VERSION_ID >= 80100) {
+            yield [
+                new PropertyTypeEnum(SuitEnum::class, true),
+                new PropertyTypeUnknown(false),
+                SuitEnum::class,
+                false,
+            ];
+        }
 
         yield [
             new PropertyTypeIterable(new PropertyTypePrimitive('bool', false), false, true),
@@ -155,7 +166,7 @@ class PropertyTypeTest extends TestCase
      */
     private function getDifferentTypes(): array
     {
-        return [
+        $types = [
             new PropertyTypeUnknown(true),
             new PropertyTypePrimitive('string', true),
             new PropertyTypePrimitive('int', true),
@@ -166,5 +177,11 @@ class PropertyTypeTest extends TestCase
             new PropertyTypeIterable(new PropertyTypePrimitive('int', false), false, true),
             new PropertyTypeIterable(new PropertyTypePrimitive('string', false), true, true),
         ];
+
+        if (\PHP_VERSION_ID >= 80100) {
+            $types[] = new PropertyTypeEnum(SuitEnum::class, true);
+        }
+
+        return $types;
     }
 }

--- a/tests/ModelParser/Fixtures/DirectionEnum.php
+++ b/tests/ModelParser/Fixtures/DirectionEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\MetadataParser\ModelParser\Fixtures;
+
+enum DirectionEnum
+{
+    case North;
+    case South;
+}

--- a/tests/ModelParser/Fixtures/EnumModel.php
+++ b/tests/ModelParser/Fixtures/EnumModel.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\MetadataParser\ModelParser\Fixtures;
+
+class EnumModel
+{
+    public SuitEnum $suit;
+    public ?DirectionEnum $direction;
+}

--- a/tests/ModelParser/Fixtures/SuitEnum.php
+++ b/tests/ModelParser/Fixtures/SuitEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\MetadataParser\ModelParser\Fixtures;
+
+enum SuitEnum: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+}

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -1539,10 +1539,6 @@ class JMSParserTest extends TestCase
 
     public function testUnionDiscriminator(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Intersection property types are only supported in PHP 8.1 or newer');
-        }
-
         $classMetadata = new RawClassMetadata(ClassUsingUnionDiscriminator::class);
 
         $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
@@ -1558,10 +1554,6 @@ class JMSParserTest extends TestCase
 
     public function testUnionDiscriminatorWithTyping(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Intersection property types are only supported in PHP 8.1 or newer');
-        }
-
         $classMetadata = new RawClassMetadata(ClassUsingUnionTyping::class);
 
         $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());

--- a/tests/ModelParser/JMSParserTest.php
+++ b/tests/ModelParser/JMSParserTest.php
@@ -7,6 +7,7 @@ namespace Tests\Liip\MetadataParser\ModelParser;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\AnnotationReader;
 use JMS\Serializer\Annotation as JMS;
+use JMS\Serializer\Annotation\UnionDiscriminator;
 use Liip\MetadataParser\Exception\ParseException;
 use Liip\MetadataParser\Metadata\PropertyAccessor;
 use Liip\MetadataParser\Metadata\PropertyType;
@@ -1539,6 +1540,10 @@ class JMSParserTest extends TestCase
 
     public function testUnionDiscriminator(): void
     {
+        if (!class_exists(UnionDiscriminator::class)) {
+            $this->markTestSkipped('UnionDiscriminator attribute from JMS missing');
+        }
+
         $classMetadata = new RawClassMetadata(ClassUsingUnionDiscriminator::class);
 
         $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());
@@ -1554,6 +1559,10 @@ class JMSParserTest extends TestCase
 
     public function testUnionDiscriminatorWithTyping(): void
     {
+        if (!class_exists(UnionDiscriminator::class)) {
+            $this->markTestSkipped('UnionDiscriminator attribute from JMS missing');
+        }
+
         $classMetadata = new RawClassMetadata(ClassUsingUnionTyping::class);
 
         $this->parser->parse($classMetadata, new SnakeCasePropertyNamingStrategy());

--- a/tests/ModelParser/Model/ClassWithEnums.php
+++ b/tests/ModelParser/Model/ClassWithEnums.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Liip\MetadataParser\ModelParser\Model;
+
+use JMS\Serializer\Annotation\Type;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\DirectionEnum;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\SuitEnum;
+
+class ClassWithEnums
+{
+    #[Type('enum<'.SuitEnum::class.'>')]
+    public SuitEnum $suit;
+
+    #[Type('enum<'.SuitEnum::class.", 'name'>")]
+    public SuitEnum $suitWithName;
+
+    #[Type('enum')]
+    public SuitEnum $suitWithoutType;
+
+    public DirectionEnum $direction;
+}

--- a/tests/ModelParser/ReflectionParserTest.php
+++ b/tests/ModelParser/ReflectionParserTest.php
@@ -94,7 +94,7 @@ class ReflectionParserTest extends TestCase
     public function testTypedProperties(): void
     {
         if (version_compare(\PHP_VERSION, '7.4.0', '<')) {
-            $this->markTestSkipped('Primitive property types are only supported in PHP 7.4 or newer');
+            $this->markTestSkipped('UnionDiscriminator attribute from JMS missing');
         }
 
         $rawClassMetadata = new RawClassMetadata(TypeDeclarationModel::class);
@@ -122,7 +122,7 @@ class ReflectionParserTest extends TestCase
     public function testTypedPropertiesUnion(): void
     {
         if (version_compare(\PHP_VERSION, '8.0.0', '<')) {
-            $this->markTestSkipped('Union property types are only supported in PHP 8.0 or newer');
+            $this->markTestSkipped('UnionDiscriminator attribute from JMS missing');
         }
 
         $rawClassMetadata = new RawClassMetadata(UnionTypeDeclarationModel::class);

--- a/tests/ModelParser/ReflectionParserTest.php
+++ b/tests/ModelParser/ReflectionParserTest.php
@@ -144,10 +144,6 @@ class ReflectionParserTest extends TestCase
 
     public function testTypedPropertiesIntersection(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Intersection property types are only supported in PHP 8.1 or newer');
-        }
-
         $rawClassMetadata = new RawClassMetadata(IntersectionTypeDeclarationModel::class);
         $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
 
@@ -163,10 +159,6 @@ class ReflectionParserTest extends TestCase
 
     public function testTypedEnumProperties(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
-        }
-
         $rawClassMetadata = new RawClassMetadata(EnumModel::class);
         $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
 

--- a/tests/ModelParser/ReflectionParserTest.php
+++ b/tests/ModelParser/ReflectionParserTest.php
@@ -8,6 +8,7 @@ use Liip\MetadataParser\Exception\ParseException;
 use Liip\MetadataParser\Metadata\ParameterMetadata;
 use Liip\MetadataParser\Metadata\PropertyType;
 use Liip\MetadataParser\Metadata\PropertyTypeClass;
+use Liip\MetadataParser\Metadata\PropertyTypeEnum;
 use Liip\MetadataParser\Metadata\PropertyTypePrimitive;
 use Liip\MetadataParser\Metadata\PropertyTypeUnion;
 use Liip\MetadataParser\Metadata\PropertyTypeUnknown;
@@ -17,7 +18,10 @@ use Liip\MetadataParser\ModelParser\RawMetadata\PropertyVariationMetadata;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
 use Liip\MetadataParser\ModelParser\ReflectionParser;
 use PHPUnit\Framework\TestCase;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\DirectionEnum;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\EnumModel;
 use Tests\Liip\MetadataParser\ModelParser\Fixtures\IntersectionTypeDeclarationModel;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\SuitEnum;
 use Tests\Liip\MetadataParser\ModelParser\Fixtures\TypeDeclarationModel;
 use Tests\Liip\MetadataParser\ModelParser\Fixtures\UnionTypeDeclarationModel;
 use Tests\Liip\MetadataParser\ModelParser\Model\ReflectionBaseModel;
@@ -155,6 +159,36 @@ class ReflectionParserTest extends TestCase
         $this->assertProperty('property1', false, false, $property1);
         // For now, just make sure we don't crash on intersection types. In context of serializing, we can probably not do anything meaningful with a intersection type anyways.
         $this->assertPropertyType($property1->getType(), PropertyTypeUnknown::class, 'mixed', true);
+    }
+
+    public function testTypedEnumProperties(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
+        }
+
+        $rawClassMetadata = new RawClassMetadata(EnumModel::class);
+        $this->parser->parse($rawClassMetadata, new SnakeCasePropertyNamingStrategy());
+
+        $props = $rawClassMetadata->getPropertyCollections();
+        $this->assertCount(2, $props, 'Number of class metadata properties should match');
+
+        $this->assertPropertyCollection('suit', 1, $props[0]);
+        $suit = $props[0]->getVariations()[0];
+
+        $this->assertPropertyType($suit->getType(), PropertyTypeEnum::class, SuitEnum::class, false);
+
+        /** @var PropertyTypeEnum $suitType */
+        $suitType = $suit->getType();
+        $this->assertSame('string', $suitType->getBackingType());
+
+        $this->assertPropertyCollection('direction', 1, $props[1]);
+        $direction = $props[1]->getVariations()[0];
+        $this->assertPropertyType($direction->getType(), PropertyTypeEnum::class, DirectionEnum::class.'|null', true);
+
+        /** @var PropertyTypeEnum $directionType */
+        $directionType = $direction->getType();
+        $this->assertNull($directionType->getBackingType());
     }
 
     public function testPrefilledClassMetadata(): void

--- a/tests/ModelParser/VisibilityAwarePropertyAccessGuesserTest.php
+++ b/tests/ModelParser/VisibilityAwarePropertyAccessGuesserTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Liip\MetadataParser\ModelParser;
 
-use Generator;
 use Liip\MetadataParser\ModelParser\ModelParserInterface;
 use Liip\MetadataParser\ModelParser\NamingStrategy\SnakeCasePropertyNamingStrategy;
 use Liip\MetadataParser\ModelParser\RawMetadata\RawClassMetadata;
@@ -57,15 +56,15 @@ class VisibilityAwarePropertyAccessGuesserTest extends TestCase
     }
 
     /**
-     * @return Generator<array{
+     * @return \Generator<array{
      *  'class': object,
      *  'parsers': ModelParserInterface[],
      *  'expectedPropertyCount': int,
-     *  'accessType': null|array{
+     *  'accessType': array{
      *     'public': bool,
-     *     'hasGetter': null|bool,
-     *     'hasSetter': null|bool,
-     *  },
+     *     'hasGetter': bool|null,
+     *     'hasSetter': bool|null,
+     *  }|null,
      * }>
      */
     public static function provideSimpleClassesCases(): iterable

--- a/tests/TypeParser/JMSTypeParserTest.php
+++ b/tests/TypeParser/JMSTypeParserTest.php
@@ -222,10 +222,6 @@ class JMSTypeParserTest extends TestCase
 
     public function testEnumBackedParsesAsPropertyTypeEnum(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
-        }
-
         /** @var PropertyTypeEnum $type */
         $type = $this->parser->parse('enum<'.SuitEnum::class.'>');
 
@@ -239,10 +235,6 @@ class JMSTypeParserTest extends TestCase
 
     public function testEnumUnitParsesAsPropertyTypeEnum(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
-        }
-
         /** @var PropertyTypeEnum $type */
         $type = $this->parser->parse('enum<'.DirectionEnum::class.'>');
         $this->assertInstanceOf(PropertyTypeEnum::class, $type);
@@ -254,10 +246,6 @@ class JMSTypeParserTest extends TestCase
 
     public function testEnumWithNameModeDisablesValueSerialization(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
-        }
-
         /** @var PropertyTypeEnum $type */
         $type = $this->parser->parse('enum<'.SuitEnum::class.", 'name'>");
         $this->assertInstanceOf(PropertyTypeEnum::class, $type);
@@ -268,10 +256,6 @@ class JMSTypeParserTest extends TestCase
 
     public function testEnumWithValueModeKeepsValueSerialization(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
-        }
-
         /** @var PropertyTypeEnum $type */
         $type = $this->parser->parse('enum<'.SuitEnum::class.", 'value'>");
         $this->assertInstanceOf(PropertyTypeEnum::class, $type);
@@ -282,10 +266,6 @@ class JMSTypeParserTest extends TestCase
 
     public function testArrayOfEnumParsesCorrectly(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
-        }
-
         /** @var PropertyTypeIterable $type */
         $type = $this->parser->parse('array<enum<'.SuitEnum::class.'>>');
         $this->assertInstanceOf(PropertyTypeIterable::class, $type);
@@ -297,20 +277,12 @@ class JMSTypeParserTest extends TestCase
 
     public function testEnumWithoutClassParamThrows(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
-        }
-
         $this->expectException(InvalidTypeException::class);
         $this->parser->parse('enum');
     }
 
     public function testEnumWithValueSerializationModeButNoSupportedBackedEnumThrowsException(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
-        }
-
         $this->expectException(InvalidTypeException::class);
         $this->parser->parse('enum<'.DirectionEnum::class.', \'value\'>');
     }

--- a/tests/TypeParser/JMSTypeParserTest.php
+++ b/tests/TypeParser/JMSTypeParserTest.php
@@ -6,8 +6,12 @@ namespace Tests\Liip\MetadataParser\TypeParser;
 
 use Liip\MetadataParser\Exception\InvalidTypeException;
 use Liip\MetadataParser\Metadata\PropertyTypeDateTime;
+use Liip\MetadataParser\Metadata\PropertyTypeEnum;
+use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\TypeParser\JMSTypeParser;
 use PHPUnit\Framework\TestCase;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\DirectionEnum;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\SuitEnum;
 
 /**
  * @small
@@ -214,5 +218,100 @@ class JMSTypeParserTest extends TestCase
     {
         $this->expectException(InvalidTypeException::class);
         $this->parser->parse('array<string, int, bool>');
+    }
+
+    public function testEnumBackedParsesAsPropertyTypeEnum(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
+        }
+
+        /** @var PropertyTypeEnum $type */
+        $type = $this->parser->parse('enum<'.SuitEnum::class.'>');
+
+        $this->assertInstanceOf(PropertyTypeEnum::class, $type);
+        $this->assertSame(SuitEnum::class, $type->getClassName());
+        $this->assertTrue($type->isNullable());
+        $this->assertTrue($type->isBackedEnum());
+        $this->assertNull($type->getSerializationMode());
+        $this->assertTrue($type->shouldSerializeAsValue());
+    }
+
+    public function testEnumUnitParsesAsPropertyTypeEnum(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
+        }
+
+        /** @var PropertyTypeEnum $type */
+        $type = $this->parser->parse('enum<'.DirectionEnum::class.'>');
+        $this->assertInstanceOf(PropertyTypeEnum::class, $type);
+        $this->assertSame(DirectionEnum::class, $type->getClassName());
+        $this->assertFalse($type->isBackedEnum());
+        $this->assertNull($type->getSerializationMode());
+        $this->assertFalse($type->shouldSerializeAsValue());
+    }
+
+    public function testEnumWithNameModeDisablesValueSerialization(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
+        }
+
+        /** @var PropertyTypeEnum $type */
+        $type = $this->parser->parse('enum<'.SuitEnum::class.", 'name'>");
+        $this->assertInstanceOf(PropertyTypeEnum::class, $type);
+        $this->assertTrue($type->isBackedEnum());
+        $this->assertSame('name', $type->getSerializationMode());
+        $this->assertFalse($type->shouldSerializeAsValue());
+    }
+
+    public function testEnumWithValueModeKeepsValueSerialization(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
+        }
+
+        /** @var PropertyTypeEnum $type */
+        $type = $this->parser->parse('enum<'.SuitEnum::class.", 'value'>");
+        $this->assertInstanceOf(PropertyTypeEnum::class, $type);
+        $this->assertTrue($type->isBackedEnum());
+        $this->assertSame('value', $type->getSerializationMode());
+        $this->assertTrue($type->shouldSerializeAsValue());
+    }
+
+    public function testArrayOfEnumParsesCorrectly(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
+        }
+
+        /** @var PropertyTypeIterable $type */
+        $type = $this->parser->parse('array<enum<'.SuitEnum::class.'>>');
+        $this->assertInstanceOf(PropertyTypeIterable::class, $type);
+        $subType = $type->getLeafType();
+        $this->assertInstanceOf(PropertyTypeEnum::class, $subType);
+        $this->assertSame(SuitEnum::class, $subType->getClassName());
+        $this->assertFalse($subType->isNullable()); // sub-types in JMS arrays are non-nullable
+    }
+
+    public function testEnumWithoutClassParamThrows(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
+        }
+
+        $this->expectException(InvalidTypeException::class);
+        $this->parser->parse('enum');
+    }
+
+    public function testEnumWithValueSerializationModeButNoSupportedBackedEnumThrowsException(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum types are only supported in PHP 8.1 or newer');
+        }
+
+        $this->expectException(InvalidTypeException::class);
+        $this->parser->parse('enum<'.DirectionEnum::class.', \'value\'>');
     }
 }

--- a/tests/TypeParser/JMSTypeParserTest.php
+++ b/tests/TypeParser/JMSTypeParserTest.php
@@ -12,6 +12,7 @@ use Liip\MetadataParser\TypeParser\JMSTypeParser;
 use PHPUnit\Framework\TestCase;
 use Tests\Liip\MetadataParser\ModelParser\Fixtures\DirectionEnum;
 use Tests\Liip\MetadataParser\ModelParser\Fixtures\SuitEnum;
+use Tests\Liip\MetadataParser\ModelParser\Model\ClassWithEnums;
 
 /**
  * @small
@@ -273,6 +274,20 @@ class JMSTypeParserTest extends TestCase
         $this->assertInstanceOf(PropertyTypeEnum::class, $subType);
         $this->assertSame(SuitEnum::class, $subType->getClassName());
         $this->assertFalse($subType->isNullable()); // sub-types in JMS arrays are non-nullable
+    }
+
+    public function testEnumWithoutTypeButWithReflection(): void
+    {
+        $reflection = new \ReflectionClass(ClassWithEnums::class);
+        $reflectionProperty = $reflection->getProperty('suitWithoutType');
+
+        /** @var PropertyTypeIterable $type */
+        $type = $this->parser->parse('enum', $reflectionProperty);
+
+        $this->assertInstanceOf(PropertyTypeEnum::class, $type);
+        $this->assertTrue($type->isBackedEnum());
+        $this->assertNull($type->getSerializationMode());
+        $this->assertTrue($type->shouldSerializeAsValue());
     }
 
     public function testEnumWithoutClassParamThrows(): void

--- a/tests/TypeParser/JMSTypeParserTest.php
+++ b/tests/TypeParser/JMSTypeParserTest.php
@@ -8,6 +8,7 @@ use Liip\MetadataParser\Exception\InvalidTypeException;
 use Liip\MetadataParser\Metadata\PropertyTypeDateTime;
 use Liip\MetadataParser\Metadata\PropertyTypeEnum;
 use Liip\MetadataParser\Metadata\PropertyTypeIterable;
+use Liip\MetadataParser\Metadata\SerializationMode;
 use Liip\MetadataParser\TypeParser\JMSTypeParser;
 use PHPUnit\Framework\TestCase;
 use Tests\Liip\MetadataParser\ModelParser\Fixtures\DirectionEnum;
@@ -251,7 +252,7 @@ class JMSTypeParserTest extends TestCase
         $type = $this->parser->parse('enum<'.SuitEnum::class.", 'name'>");
         $this->assertInstanceOf(PropertyTypeEnum::class, $type);
         $this->assertTrue($type->isBackedEnum());
-        $this->assertSame('name', $type->getSerializationMode());
+        $this->assertSame(SerializationMode::Name, $type->getSerializationMode());
         $this->assertFalse($type->shouldSerializeAsValue());
     }
 
@@ -261,7 +262,7 @@ class JMSTypeParserTest extends TestCase
         $type = $this->parser->parse('enum<'.SuitEnum::class.", 'value'>");
         $this->assertInstanceOf(PropertyTypeEnum::class, $type);
         $this->assertTrue($type->isBackedEnum());
-        $this->assertSame('value', $type->getSerializationMode());
+        $this->assertSame(SerializationMode::Value, $type->getSerializationMode());
         $this->assertTrue($type->shouldSerializeAsValue());
     }
 

--- a/tests/TypeParser/PhpTypeParserTest.php
+++ b/tests/TypeParser/PhpTypeParserTest.php
@@ -275,10 +275,6 @@ class PhpTypeParserTest extends TestCase
 
     public function testEnumReflectionType(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
-        }
-
         $reflClass = new \ReflectionClass(EnumModel::class);
 
         $type = $this->parser->parseReflectionType($reflClass->getProperty('direction')->getType());
@@ -292,10 +288,6 @@ class PhpTypeParserTest extends TestCase
 
     public function testBackedEnumReflectionType(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
-        }
-
         $reflClass = new \ReflectionClass(EnumModel::class);
 
         $type = $this->parser->parseReflectionType($reflClass->getProperty('suit')->getType());
@@ -309,10 +301,6 @@ class PhpTypeParserTest extends TestCase
 
     public function testEnumAnnotationType(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
-        }
-
         $type = $this->parser->parseAnnotationType('\\'.SuitEnum::class, new \ReflectionClass($this));
 
         $this->assertInstanceOf(PropertyTypeEnum::class, $type);
@@ -324,10 +312,6 @@ class PhpTypeParserTest extends TestCase
 
     public function testNullableUnitEnumAnnotationType(): void
     {
-        if (\PHP_VERSION_ID < 80100) {
-            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
-        }
-
         $type = $this->parser->parseAnnotationType('\\'.DirectionEnum::class.'|null', new \ReflectionClass($this));
 
         $this->assertInstanceOf(PropertyTypeEnum::class, $type);

--- a/tests/TypeParser/PhpTypeParserTest.php
+++ b/tests/TypeParser/PhpTypeParserTest.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Tests\Liip\MetadataParser\TypeParser;
 
 use Liip\MetadataParser\Exception\InvalidTypeException;
+use Liip\MetadataParser\Metadata\PropertyTypeEnum;
 use Liip\MetadataParser\Metadata\PropertyTypeIterable;
 use Liip\MetadataParser\TypeParser\PhpTypeParser;
 use PHPUnit\Framework\TestCase;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\DirectionEnum;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\EnumModel;
+use Tests\Liip\MetadataParser\ModelParser\Fixtures\SuitEnum;
 use Tests\Liip\MetadataParser\ModelParser\Model\BaseModel;
 use Tests\Liip\MetadataParser\ModelParser\Model\ReflectionAbstractModel;
 use Tests\Liip\MetadataParser\ModelParser\Model\WithImports;
@@ -267,5 +271,69 @@ class PhpTypeParserTest extends TestCase
         if (null !== $expectedNullable) {
             $this->assertSame($expectedNullable, $type->isNullable(), 'Nullable flag should match');
         }
+    }
+
+    public function testEnumReflectionType(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
+        }
+
+        $reflClass = new \ReflectionClass(EnumModel::class);
+
+        $type = $this->parser->parseReflectionType($reflClass->getProperty('direction')->getType());
+
+        $this->assertInstanceOf(PropertyTypeEnum::class, $type);
+        $this->assertNull($type->getBackingType());
+        $this->assertFalse($type->shouldSerializeAsValue());
+        $this->assertNull($type->getSerializationMode());
+        $this->assertTrue($type->isNullable());
+    }
+
+    public function testBackedEnumReflectionType(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
+        }
+
+        $reflClass = new \ReflectionClass(EnumModel::class);
+
+        $type = $this->parser->parseReflectionType($reflClass->getProperty('suit')->getType());
+
+        $this->assertInstanceOf(PropertyTypeEnum::class, $type);
+        $this->assertSame('string', $type->getBackingType());
+        $this->assertTrue($type->shouldSerializeAsValue());
+        $this->assertNull($type->getSerializationMode());
+        $this->assertFalse($type->isNullable());
+    }
+
+    public function testEnumAnnotationType(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
+        }
+
+        $type = $this->parser->parseAnnotationType('\\'.SuitEnum::class, new \ReflectionClass($this));
+
+        $this->assertInstanceOf(PropertyTypeEnum::class, $type);
+        $this->assertSame('string', $type->getBackingType());
+        $this->assertTrue($type->shouldSerializeAsValue());
+        $this->assertNull($type->getSerializationMode());
+        $this->assertFalse($type->isNullable());
+    }
+
+    public function testNullableUnitEnumAnnotationType(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('Enum support requires PHP 8.1 or newer');
+        }
+
+        $type = $this->parser->parseAnnotationType('\\'.DirectionEnum::class.'|null', new \ReflectionClass($this));
+
+        $this->assertInstanceOf(PropertyTypeEnum::class, $type);
+        $this->assertNull($type->getBackingType());
+        $this->assertFalse($type->shouldSerializeAsValue());
+        $this->assertNull($type->getSerializationMode());
+        $this->assertTrue($type->isNullable());
     }
 }


### PR DESCRIPTION
This adds enum support for JMS and simple enum types without any jms attributes

I also took this as an opportunity to update `phpstan` and `php-cs-fixer` to their latest version.