### PR TITLE
Use proper type for class map

### DIFF
--- a/src/Metadata/ClassDiscriminatorMetadata.php
+++ b/src/Metadata/ClassDiscriminatorMetadata.php
@@ -15,7 +15,7 @@ class ClassDiscriminatorMetadata
     public bool $disabled = false;
 
     /**
-     * @var string[]
+     * @var array<string, class-string>
      */
     public array $classMap = [];
 


### PR DESCRIPTION
This was enough to get phpstan not complain anymore about wrong types in https://github.com/liip/serializer/pull/51